### PR TITLE
Improve network latency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -153,4 +153,5 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.1'
 }

--- a/app/src/main/java/com/grammatek/simaromur/AppRepository.java
+++ b/app/src/main/java/com/grammatek/simaromur/AppRepository.java
@@ -43,7 +43,7 @@ public class AppRepository {
     private List<VoiceResponse> mTiroVoices;
     private final ApiDbUtil mApiDbUtil;
     private final MediaPlayer mMediaPlayer;
-    static final int SAMPLE_RATE_WAV= 22050;
+    static final int SAMPLE_RATE_WAV= 16000;
     static final int SAMPLE_RATE_MP3= 22050;
     // this saves the voice name to use for the next speech synthesis
     private Voice mSelectedVoice;

--- a/app/src/main/java/com/grammatek/simaromur/AppRepository.java
+++ b/app/src/main/java/com/grammatek/simaromur/AppRepository.java
@@ -128,7 +128,7 @@ public class AppRepository {
         public void update(byte[] ttsData) {
             Log.v(LOG_TAG, "TiroTtsObserver: Tiro API returned: " + ttsData.length + " bytes");
             if (ttsData.length == 0) {
-                playSilence();
+                Log.v(LOG_TAG, "TiroTtsObserver: Nothing to speak");
                 return;
             }
             m_synthCb.start(SAMPLE_RATE_WAV, AudioFormat.ENCODING_PCM_16BIT, 1);
@@ -141,20 +141,12 @@ public class AppRepository {
                 m_synthCb.audioAvailable(ttsData, offset, bytesConsumed);
                 offset += bytesConsumed;
             }
+            Log.v(LOG_TAG, "TiroTtsObserver: consumed " + offset + " bytes");
             m_synthCb.done();
         }
 
         public void error(String errorMsg) {
             Log.e(LOG_TAG, "TiroTtsObserver()::error: " + errorMsg);
-            playSilence();
-        }
-
-        private void playSilence() {
-            Log.v(LOG_TAG, "TiroTtsObserver()::playing silence ...");
-            m_synthCb.start(SAMPLE_RATE_WAV, AudioFormat.ENCODING_PCM_16BIT, 1);
-            byte[] silenceData = new byte[m_synthCb.getMaxBufferSize()];
-            m_synthCb.audioAvailable(silenceData, 0, silenceData.length);
-            m_synthCb.done();
         }
     }
 
@@ -297,6 +289,10 @@ public class AppRepository {
     public void startTiroTts(SynthesisCallback synthCb, Voice voice, String text, float speed, float pitch) {
         // map given voice to voiceId
         if (voice != null) {
+            if (text.trim().isEmpty()) {
+                Log.w(LOG_TAG, "startTiroTts: given text is whitespace only ?!");
+            }
+
             final String SampleRate = "" + SAMPLE_RATE_WAV;
             SpeakRequest request = new SpeakRequest("standard", voice.languageCode,
                     "pcm", SampleRate, text, "text", voice.internalName);

--- a/app/src/main/java/com/grammatek/simaromur/TTSService.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSService.java
@@ -75,11 +75,11 @@ public class TTSService extends TextToSpeechService {
         String voiceName = request.getVoiceName();
         int speechrate = request.getSpeechRate();
         int pitch = request.getPitch();
-        Log.i(LOG_TAG, "onSynthesizeText: (" + language + "/"+country+"/"+variant+"), voice: "
+        Log.v(LOG_TAG, "onSynthesizeText: (" + language + "/"+country+"/"+variant+"), voice: "
                 + voiceName);
         String loadedVoiceName = mRepository.getLoadedVoiceName();
         if (!loadedVoiceName.equals(voiceName)) {
-            Log.e(LOG_TAG, "Loaded voice ("+loadedVoiceName+") and given voice ("+voiceName+") differ ?!");
+            Log.e(LOG_TAG, "onSynthesizeText: Loaded voice ("+loadedVoiceName+") and given voice ("+voiceName+") differ ?!");
         }
 
         com.grammatek.simaromur.db.Voice voice = mRepository.getVoiceForName(loadedVoiceName);
@@ -87,10 +87,10 @@ public class TTSService extends TextToSpeechService {
             NormalizationManager normalizationManager = App.getApplication().getNormalizationManager();
             String normalizedText = normalizationManager.process(text);
 
-            Log.i(LOG_TAG, text + " => normalized =>" + normalizedText);
+            Log.v(LOG_TAG, text + "onSynthesizeText:  => normalized =>" + normalizedText);
             if (normalizedText.isEmpty()) {
-                // @todo: if there is nothing to speak, we don't need to access the API ... ?!
-                normalizedText = " ";
+                Log.i(LOG_TAG, "onSynthesizeText: finished");
+                return;
             }
             mRepository.startTiroTts(callback, voice, normalizedText, speechrate, pitch/100.0f);
         }

--- a/app/src/main/java/com/grammatek/simaromur/network/tiro/SpeakController.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/tiro/SpeakController.java
@@ -4,17 +4,12 @@ import android.util.Log;
 
 import com.grammatek.simaromur.network.tiro.pojo.SpeakRequest;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import java.io.IOException;
 
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
-import retrofit2.Retrofit;
-import retrofit2.converter.gson.GsonConverterFactory;
 
 public class SpeakController implements Callback<ResponseBody> {
     private final static String LOG_TAG = "Simaromur_Tiro" + SpeakController.class.getSimpleName();
@@ -111,16 +106,7 @@ public class SpeakController implements Callback<ResponseBody> {
      * @return  a caller object, still needs to be executed
      */
     private Call<ResponseBody> buildSpeakCall(SpeakRequest speakRequest) {
-        Gson gson = new GsonBuilder()
-                .setLenient()
-                .create();
-
-        Retrofit retrofit = new Retrofit.Builder()
-                .baseUrl(TiroAPI.URL)
-                .addConverterFactory(GsonConverterFactory.create(gson))
-                .build();
-
-        TiroAPI tiroAPI = retrofit.create(TiroAPI.class);
+        TiroAPI tiroAPI = TiroServiceGenerator.createService(TiroAPI.class);
         return tiroAPI.postSpeakRequest(speakRequest);
     }
 

--- a/app/src/main/java/com/grammatek/simaromur/network/tiro/TiroAPI.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/tiro/TiroAPI.java
@@ -13,7 +13,7 @@ import retrofit2.http.POST;
 import retrofit2.http.Query;
 
 public interface TiroAPI {
-    public static final String URL = "https://tts.tiro.is/v0/";
+    String URL = "https://tts.tiro.is/v0/";
 
     @GET("voices")
     Call<List<VoiceResponse>> queryVoices(@Query("LanguageCode") String languageCode);

--- a/app/src/main/java/com/grammatek/simaromur/network/tiro/TiroServiceGenerator.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/tiro/TiroServiceGenerator.java
@@ -1,0 +1,64 @@
+package com.grammatek.simaromur.network.tiro;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.util.Arrays;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+/**
+ * Generate TiroService accessor.
+ * All members of the class are statically initialized and therefore cached for the lifetime of
+ * the application. This way, we use the same Http client for all further requests to Tiro API.
+ * Furthermore explicitly use the order of protocols http_2, http_1_1. okhttp
+ * will use automatically http2, if server supports it.
+ */
+public class TiroServiceGenerator {
+
+    private static final Gson gson = new GsonBuilder().setLenient().create();
+
+    private static final Retrofit.Builder builder
+            = new Retrofit.Builder()
+            .baseUrl(TiroAPI.URL)
+            .addConverterFactory(GsonConverterFactory.create(gson));
+
+    private static Retrofit retrofit = builder.build();
+
+    private static final OkHttpClient.Builder httpClient
+            = new OkHttpClient.Builder().protocols(Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1));
+
+    private static final HttpLoggingInterceptor logging
+            = new HttpLoggingInterceptor()
+            .setLevel(HttpLoggingInterceptor.Level.BASIC);
+
+    public static <S> S createService(Class<S> serviceClass) {
+        if (!httpClient.interceptors().contains(logging)) {
+            httpClient.addInterceptor(logging);
+            builder.client(httpClient.build());
+            retrofit = builder.build();
+        }
+        return retrofit.create(serviceClass);
+    }
+
+    public static <S> S createService(Class<S> serviceClass, final String token) {
+        if (token != null) {
+            httpClient.interceptors().clear();
+            httpClient.addInterceptor( chain -> {
+                Request original = chain.request();
+                Request.Builder builder1 = original.newBuilder()
+                        .header("Authorization", token);
+                Request request = builder1.build();
+                return chain.proceed(request);
+            });
+            builder.client(httpClient.build());
+            retrofit = builder.build();
+        }
+        return retrofit.create(serviceClass);
+    }
+}

--- a/app/src/main/java/com/grammatek/simaromur/network/tiro/VoiceController.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/tiro/VoiceController.java
@@ -2,21 +2,14 @@ package com.grammatek.simaromur.network.tiro;
 
 import android.util.Log;
 
-import com.grammatek.simaromur.network.tiro.pojo.SpeakRequest;
 import com.grammatek.simaromur.network.tiro.pojo.VoiceResponse;
 
 import java.io.IOException;
 import java.util.List;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
-import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
-import retrofit2.Retrofit;
-import retrofit2.converter.gson.GsonConverterFactory;
 
 public class VoiceController implements Callback<List<VoiceResponse>> {
     private final static String LOG_TAG = "Simaromur_Tiro" + VoiceController.class.getSimpleName();
@@ -109,16 +102,7 @@ public class VoiceController implements Callback<List<VoiceResponse>> {
      * @return  a caller object, still needs to be executed
      */
     private  Call<List<VoiceResponse>> buildQueryVoicesCall(String languageCode) {
-        Gson gson = new GsonBuilder()
-                .setLenient()
-                .create();
-
-        Retrofit retrofit = new Retrofit.Builder()
-                .baseUrl(TiroAPI.URL)
-                .addConverterFactory(GsonConverterFactory.create(gson))
-                .build();
-
-        TiroAPI tiroAPI = retrofit.create(TiroAPI.class);
+        TiroAPI tiroAPI = TiroServiceGenerator.createService(TiroAPI.class);
         return tiroAPI.queryVoices(languageCode);
     }
 


### PR DESCRIPTION
## Introduce class `TiroServiceGenerator`: use static initialization for http client

- All members of the class are statically initialized and therefore cached for the lifetime of the application. This way, we use the same http client for all requests to Tiro API.
- Furthermore explicitely use the order of protocols http_2, http_1_1. okhttp will use automatically http2, if server supports it.
- Enable also the logging interceptor and prepare TiroServiceGgenerator for token based authentication.
- Adapt SpeakController/VoiceController to use the new class.

## `AppRepository.java`
- use 16000Hz as sample rate for PCM audio.

## AppRepository: change handling of utternace end:

- Remove `playSilence()` call
- if empty string is given to us, just return out of onSynthesizeText() instead of calling Tiro API.
- decrease logging level of text output to Verbose
