### PR TITLE
Show warning dialog, if Símarómur is not the default TTS engine

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/TTSManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSManager.java
@@ -55,6 +55,11 @@ public class TTSManager extends Activity implements OnItemClickListener, TextToS
         startActivityForResult(checkIntent, MY_DATA_CHECK_CODE);
     }
 
+    /**
+     * Method to fulfill TextToSpeech.OnInitListener interface.
+     *
+     * @param status status of TTS engine
+     */
     @Override
     public void onInit(final int status) {
         Log.v(LOG_TAG, "onInit: status: " + status);
@@ -142,17 +147,18 @@ public class TTSManager extends Activity implements OnItemClickListener, TextToS
     }
 
     /**
-     * This method is called, when the TTS system is bound to this activity. Before that, it might
-     * well be that onResume or on
+     * This method is called, when the TTS system is bound to this activity. Before, onResume()
+     * can be called.
      *
-     * @param requestCode
-     * @param resultCode
-     * @param data
+     * @param requestCode   The user-defined number provided when starting the activity
+     * @param resultCode    Result code / outcome of the activity
+     * @param data          optional data from the intent
      */
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         Log.v(LOG_TAG, "onActivityResult: resultCode: " + resultCode);
         if (requestCode == MY_DATA_CHECK_CODE) {
-            // success, create the TTS instance, this also pulls up our TTSService
+            // Create the TTS instance, this also pulls up our TTSService. Anywhere we use
+            // this object, we must always check beforehand mTtsClient != null.
             mTtsClient = new TextToSpeech(this, this,
                     getApplicationContext().getPackageName());
         }
@@ -163,9 +169,7 @@ public class TTSManager extends Activity implements OnItemClickListener, TextToS
 
         Intent intent = new Intent(this, ICONS[position].activity);
         startActivity(intent);
-
     }
-
 
     static class LauncherIcon {
         final String text;
@@ -178,7 +182,6 @@ public class TTSManager extends Activity implements OnItemClickListener, TextToS
             this.text = text;
             this.activity = activity;
         }
-
     }
 
     static class ImageAdapter extends BaseAdapter {

--- a/app/src/main/java/com/grammatek/simaromur/TTSManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSManager.java
@@ -1,9 +1,12 @@
 package com.grammatek.simaromur;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.speech.tts.TextToSpeech;
+import android.util.Log;
 import android.view.MotionEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -15,12 +18,15 @@ import android.widget.GridView;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-public class TTSManager extends Activity implements OnItemClickListener {
+public class TTSManager extends Activity implements OnItemClickListener, TextToSpeech.OnInitListener {
     private final static String LOG_TAG = "Simaromur_Java_" + TTSManager.class.getSimpleName();
+    private TextToSpeech mTtsClient;        // for querying TTS engine info
+    private AlertDialog mWarningDialog;
+    private final static int MY_DATA_CHECK_CODE = 1;
 
     static final LauncherIcon[] ICONS = {
         // @todo: we disable the FLite based choosers, we will replace local voice management
-        // completely
+        //        completely
         // new LauncherIcon(R.drawable.custom_dialog_tts, "TTS Demo", TTSDemo.class),
         // new LauncherIcon(R.drawable.custom_dialog_manage, "FLite Voices", DownloadVoiceData.class),
         new LauncherIcon(R.drawable.sim_logo, "SIM Voices", VoiceManager.class),
@@ -43,6 +49,113 @@ public class TTSManager extends Activity implements OnItemClickListener {
                 return event.getAction() == MotionEvent.ACTION_MOVE;
             }
         });
+
+        Intent checkIntent = new Intent();
+        checkIntent.setAction(TextToSpeech.Engine.ACTION_CHECK_TTS_DATA);
+        startActivityForResult(checkIntent, MY_DATA_CHECK_CODE);
+    }
+
+    @Override
+    public void onInit(final int status) {
+        Log.v(LOG_TAG, "onInit: status: " + status);
+    }
+
+    /**
+     * Checks if our service is the TTS default service
+     */
+    private void checkDefaultEngine() {
+        Log.v(LOG_TAG, "checkDefaultEngine()");
+        if (mTtsClient == null) {
+            Log.v(LOG_TAG, "No TTS connection ?!");
+            return;
+        }
+        try {
+            final String initEngine = mTtsClient.getDefaultEngine();
+            if (initEngine != null) {
+                Log.i(LOG_TAG, "Default engine: " + initEngine);
+                // if Símarómur is not the default engine: engage user to change that
+                if (!initEngine.equals(getApplicationContext().getPackageName())) {
+                    showTtsEngineWarningDialog();
+                }
+            }
+        } catch (final Exception e) {
+            Log.e(LOG_TAG, "TTS engine default error" + e.getMessage());
+        }
+    }
+
+    /**
+     * Shows TTS Engine warning and refers user to Android TTS service settings.
+     */
+    private void showTtsEngineWarningDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder
+            .setMessage(R.string.tts_settings)
+            .setTitle(R.string.choose_tts_engine)
+            .setCancelable(false)
+            .setPositiveButton(R.string.doit, (dialog, id) -> {
+                openTtsSettings();
+            })
+            .setNegativeButton(R.string.not_yet, (dialog, id) -> {
+                // nothing
+            });
+        if (mWarningDialog != null) {
+            mWarningDialog.cancel();
+            mWarningDialog = null;
+        }
+        mWarningDialog = builder.create();
+        mWarningDialog.show();
+    }
+
+    @Override
+    public void onResume() {
+        Log.v(LOG_TAG, "onResume:");
+        super.onResume();
+        checkDefaultEngine();
+    }
+
+    @Override
+    public void onStop() {
+        Log.v(LOG_TAG, "onStop:");
+        super.onStop();
+        if (mWarningDialog != null) {
+            mWarningDialog.cancel();
+            mWarningDialog = null;
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        Log.v(LOG_TAG, "onDestroy:");
+        super.onDestroy();
+        if (mTtsClient != null) {
+            mTtsClient.shutdown();
+            mTtsClient = null;
+        }
+    }
+
+    // Open TTS engine preferences
+    private void openTtsSettings() {
+        Intent intent = new Intent();
+        intent.setAction("com.android.settings.TTS_SETTINGS");
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(intent);
+    }
+
+    /**
+     * This method is called, when the TTS system is bound to this activity. Before that, it might
+     * well be that onResume or on
+     *
+     * @param requestCode
+     * @param resultCode
+     * @param data
+     */
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        Log.v(LOG_TAG, "onActivityResult: resultCode: " + resultCode);
+        if (requestCode == MY_DATA_CHECK_CODE) {
+            // success, create the TTS instance, this also pulls up our TTSService
+            mTtsClient = new TextToSpeech(this, this,
+                    getApplicationContext().getPackageName());
+        }
     }
 
     @Override
@@ -52,6 +165,7 @@ public class TTSManager extends Activity implements OnItemClickListener {
         startActivity(intent);
 
     }
+
 
     static class LauncherIcon {
         final String text;

--- a/app/src/main/res/values-is-rIS/strings.xml
+++ b/app/src/main/res/values-is-rIS/strings.xml
@@ -18,4 +18,10 @@
     <string name="is_IS">Íslenska</string>
     <string name="en_EN">Enska</string>
     <string name="en_US">Enska</string>
+    <string name="ok">Í lagi</string>
+    <string name="cancel">Hætta</string>
+    <string name="doit">Virkja!</string>
+    <string name="tts_settings">Áður en þú getur notað Símaróm sem skjálesara þarftu að virkja hann í stillingum fyrir talgervil</string>
+    <string name="choose_tts_engine">Mikilvægt</string>
+    <string name="not_yet">Ekki núna</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,6 @@
     <string name="cancel">Cancel</string>
     <string name="not_yet">Not yet</string>
     <string name="doit">Do it!</string>
-    <string name="tts_settings">Before you can use Símarómur as screen reader, you have to activate it in the Android TTS settings</string>
+    <string name="tts_settings">Before you can use Símarómur as a screen reader, you have to activate it in the Android TTS settings</string>
     <string name="choose_tts_engine">Important</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,10 @@
     <string name="is_IS">Icelandic</string>
     <string name="en_EN">English</string>
     <string name="en_US">U.S. English</string>
+    <string name="ok">OK</string>
+    <string name="cancel">Cancel</string>
+    <string name="not_yet">Not yet</string>
+    <string name="doit">Do it!</string>
+    <string name="tts_settings">Before you can use Símarómur as screen reader, you have to activate it in the Android TTS settings</string>
+    <string name="choose_tts_engine">Important</string>
 </resources>


### PR DESCRIPTION
`TTSManager`: Add TTS client object and show modal dialog that navigates the user to the correct TTS service settings. 

These settings have been deeply buried inside the new Android 11 settings menu, therefore we need the direct navigation shortcut from within the app. Also add proper resource deallocation handling for the new resources.
