### PR TITLE
Fix crash / better network handling

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/App.java
+++ b/app/src/main/java/com/grammatek/simaromur/App.java
@@ -8,6 +8,7 @@ import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
 import android.net.NetworkRequest;
 import android.os.Build;
+import android.util.Log;
 
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.grammatek.simaromur.frontend.NormalizationManager;
@@ -18,6 +19,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class App extends Application {
+    private final static String LOG_TAG = "Simaromur_" + App.class.getSimpleName();
     ExecutorService executorService = Executors.newFixedThreadPool(4);
     AppRepository mAppRepository;
     private FirebaseAnalytics mFirebaseAnalytics;
@@ -66,13 +68,14 @@ public class App extends Application {
 
     @Override
     public void onCreate() {
+        Log.v(LOG_TAG, "onCreate()");
         super.onCreate();
         sApplication = this;
         mConnectionChecker = new ConnectionCheck(this);
         mConnectionChecker.registerNetworkCallback();
-        mAppRepository = new AppRepository(this);
         // Obtain the FirebaseAnalytics instance.
         mFirebaseAnalytics = FirebaseAnalytics.getInstance(this);
+        mAppRepository = new AppRepository(this);
         mNormalizationManager = new NormalizationManager(this.getBaseContext());
     }
 }

--- a/app/src/main/java/com/grammatek/simaromur/App.java
+++ b/app/src/main/java/com/grammatek/simaromur/App.java
@@ -11,6 +11,7 @@ import android.os.Build;
 
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.grammatek.simaromur.frontend.NormalizationManager;
+import com.grammatek.simaromur.network.ConnectionCheck;
 
 import java.io.File;
 import java.util.concurrent.ExecutorService;
@@ -23,7 +24,7 @@ public class App extends Application {
     private static App sApplication;
 
     private NormalizationManager mNormalizationManager;
-
+    ConnectionCheck mConnectionChecker;
     public static App getApplication() {
         return sApplication;
     }
@@ -63,87 +64,12 @@ public class App extends Application {
         return mNormalizationManager;
     }
 
-    /**
-     * Returns boolean, if we have a network connection.
-     *
-     * @return  true in case network connection is available (via wifi and/or GSM)
-     *          false otherwise
-     *
-     * @todo    uses deprecated API's
-     */
-    public boolean hasNetwork() {
-        ConnectivityManager connMgr =
-                (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-        boolean isWifiConn = false;
-        boolean isMobileConn = false;
-        for (Network network : connMgr.getAllNetworks()) {
-            NetworkInfo networkInfo = connMgr.getNetworkInfo(network);
-            if (networkInfo.getType() == ConnectivityManager.TYPE_WIFI) {
-                isWifiConn |= networkInfo.isConnected();
-            }
-            if (networkInfo.getType() == ConnectivityManager.TYPE_MOBILE) {
-                isMobileConn |= networkInfo.isConnected();
-            }
-        }
-
-        return isWifiConn || isMobileConn;
-    }
-
-    /**
-     * @todo: Fiddling around with network states, this is not the right implementation, because the
-     *        callbacks are registered, but not necessarily fired before the method is finished.
-     *        We need to have these started in a class,
-     *        not just in a method and the booleans should be class variables ...
-     *        Then again, it's not clear, if we can use these API's on older devices ...
-     *        And we should ask for NET_CAPABILITY_INTERNET &  NET_CAPABILITY_VALIDATED instead of
-     *        wifi & cellular
-     */
-    public boolean hasNetwork2() {
-        final boolean[] isWifiConn = {false};
-        final boolean[] isMobileConn = {false};
-        ConnectivityManager connectivityManager =
-                (ConnectivityManager) getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
-
-        ConnectivityManager.NetworkCallback networkCallback = new ConnectivityManager.NetworkCallback() {
-            @Override
-            public void onAvailable(Network network) {
-                // network available
-                NetworkCapabilities nc = connectivityManager.getNetworkCapabilities(network);
-                if (nc.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
-                    isWifiConn[0] = true;
-                }
-                if (nc.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
-                    isMobileConn[0] = true;
-                }
-            }
-
-            @Override
-            public void onLost(Network network) {
-                // network unavailable
-                NetworkCapabilities nc = connectivityManager.getNetworkCapabilities(network);
-                if (nc.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
-                    isWifiConn[0] = false;
-                }
-                if (nc.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
-                    isMobileConn[0] = false;
-                }
-            }
-        };
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            connectivityManager.registerDefaultNetworkCallback(networkCallback);
-        } else {
-            NetworkRequest request = new NetworkRequest.Builder()
-                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET).build();
-            connectivityManager.registerNetworkCallback(request, networkCallback);
-        }
-        return isWifiConn[0] || isMobileConn[0];
-    }
-
     @Override
     public void onCreate() {
         super.onCreate();
         sApplication = this;
+        mConnectionChecker = new ConnectionCheck(this);
+        mConnectionChecker.registerNetworkCallback();
         mAppRepository = new AppRepository(this);
         // Obtain the FirebaseAnalytics instance.
         mFirebaseAnalytics = FirebaseAnalytics.getInstance(this);

--- a/app/src/main/java/com/grammatek/simaromur/CheckSimVoices.java
+++ b/app/src/main/java/com/grammatek/simaromur/CheckSimVoices.java
@@ -25,15 +25,15 @@ public class CheckSimVoices extends Activity {
         int result = TextToSpeech.Engine.CHECK_VOICE_DATA_PASS;
         Intent returnData = new Intent();
 
-        // we should already have our voice list as the query is done at Application start ...
         List<com.grammatek.simaromur.db.Voice> voices = mAppRepository.getCachedVoices();
-        if (voices.isEmpty()) {
+        if (voices == null || voices.isEmpty()) {
             Log.e(LOG_TAG, "no voices available yet ?!");
             // todo: maybe we can use direct db calls and blocking network requests, as we are
             //       probably not called here inside the UI thread ?
             result = TextToSpeech.Engine.CHECK_VOICE_DATA_FAIL;
             setResult(result, returnData);
             finish();
+            return;
         }
 
         ArrayList<String> available = new ArrayList<>();

--- a/app/src/main/java/com/grammatek/simaromur/TTSManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSManager.java
@@ -82,7 +82,10 @@ public class TTSManager extends Activity implements OnItemClickListener, TextToS
                 if (!initEngine.equals(getApplicationContext().getPackageName())) {
                     showTtsEngineWarningDialog();
                 }
+            } else {
+                Log.i(LOG_TAG, "No default engine yet ? ");
             }
+
         } catch (final Exception e) {
             Log.e(LOG_TAG, "TTS engine default error" + e.getMessage());
         }

--- a/app/src/main/java/com/grammatek/simaromur/VoiceInfo.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceInfo.java
@@ -13,6 +13,7 @@ import androidx.lifecycle.ViewModelProvider;
 
 import com.grammatek.simaromur.frontend.FrontendManager;
 import com.grammatek.simaromur.frontend.NormalizationManager;
+import com.grammatek.simaromur.network.ConnectionCheck;
 
 import static com.grammatek.simaromur.VoiceManager.EXTRA_DATA_VOICE_ID;
 
@@ -59,7 +60,7 @@ public class VoiceInfo  extends AppCompatActivity implements View.OnClickListene
         final Button button = findViewById(R.id.speak_button);
         // setup network status, @todo: this is very rough and doesn't do anything dynamic
         final ImageView networkAvailabilityIcon = findViewById(R.id.imageStatus);
-        if (App.getApplication().hasNetwork()) {
+        if (ConnectionCheck.isNetworkConnected()) {
             button.setEnabled(true);
             networkAvailabilityIcon.setImageResource(R.drawable.ic_cloud_checked_solid);
         }

--- a/app/src/main/java/com/grammatek/simaromur/VoiceManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceManager.java
@@ -41,8 +41,6 @@ public class VoiceManager extends AppCompatActivity {
             Log.v(LOG_TAG, "onChanged - voices size: " + voices.size());
             // Update cached voices
             adapter.setVoices(voices);
-            // query Network voices
-            mVoiceViewModel.startFetchingNetworkVoices("");
         });
 
         adapter.setOnItemClickListener((v, position) -> {

--- a/app/src/main/java/com/grammatek/simaromur/db/AppDataDao.java
+++ b/app/src/main/java/com/grammatek/simaromur/db/AppDataDao.java
@@ -1,5 +1,7 @@
 package com.grammatek.simaromur.db;
 
+import android.util.Log;
+
 import androidx.lifecycle.LiveData;
 import androidx.room.Dao;
 import androidx.room.Delete;
@@ -7,8 +9,14 @@ import androidx.room.Insert;
 import androidx.room.Query;
 import androidx.room.Update;
 
+import com.grammatek.simaromur.AppRepository;
+
+import java.util.Date;
+
 @Dao
 public abstract class AppDataDao {
+    private final static String LOG_TAG = "Simaromur_" + AppDataDao.class.getSimpleName();
+
     @Insert
     public abstract void insert(AppData app);
 
@@ -48,6 +56,28 @@ public abstract class AppDataDao {
     public Long getCurrentVoiceId() {
         AppData appData = getAppData();
         return appData.currentVoiceId;
+    }
+
+    /**
+     * Update voice list update date & time to now
+     */
+    public void updateVoiceListTimestamp() {
+        AppData appData = getAppData();
+        appData.simVoiceListUpdateTime = new java.util.Date();
+        Log.v(LOG_TAG, "updateVoiceListTimestamp: " + appData.simVoiceListUpdateTime);
+        update(appData);
+    }
+
+    public boolean voiceListUpdateTimeOlderThan(java.util.Date date) {
+        AppData appData = getAppData();
+        if (appData == null) {
+            return true;
+        }
+        Date lastUpdate = appData.simVoiceListUpdateTime;
+        if (lastUpdate == null) {
+            return true;
+        }
+        return (appData.simVoiceListUpdateTime.before(date));
     }
     // TODO(DS): To be continued ....
 }

--- a/app/src/main/java/com/grammatek/simaromur/db/ApplicationDb.java
+++ b/app/src/main/java/com/grammatek/simaromur/db/ApplicationDb.java
@@ -71,8 +71,7 @@ public abstract class ApplicationDb extends RoomDatabase {
         protected Void doInBackground(final Void... params) {
 
             AppData appData = mAppDataDao.getAppData();
-            if (appData == null)
-            {
+            if (appData == null) {
                 appData = new AppData();
                 appData.fliteVoiceListPath = App.getDataPath();
                 appData.simVoiceListPath = App.getVoiceDataPath();
@@ -80,18 +79,8 @@ public abstract class ApplicationDb extends RoomDatabase {
             }
 
             List<Voice> voices = mVoiceDao.getAnyVoices();
-            if (voices == null || voices.isEmpty())
-            {
-                Log.v(LOG_TAG, "PopulateDbAsync:  voices == null");
-                // fill in initial list of voices, currently via Tíro TTS web service only
-                Voice v1 = new Voice("Dóra", "Dora", "female",
-                        "is-IS", "is","clear", Voice.TYPE_TIRO, "");
-                Voice v2 = new Voice("Karl", "Karl","male",
-                        "is-IS", "is", "clear", Voice.TYPE_TIRO, "");
-                mVoiceDao.insertVoices(v1, v2);
-                Voice selectedVoice = mVoiceDao.findVoice(v2.name, v2.internalName, v2.languageCode,
-                        v2.languageName, v2.variant);
-                mAppDataDao.selectCurrentVoice(selectedVoice);
+            if (voices == null || voices.isEmpty()) {
+                Log.d(LOG_TAG, "PopulateDbAsync: no voices yet, network voices are updated async.");
             }
             return null;
         }

--- a/app/src/main/java/com/grammatek/simaromur/network/ConnectionCheck.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/ConnectionCheck.java
@@ -1,0 +1,60 @@
+package com.grammatek.simaromur.network;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkRequest;
+import android.util.Log;
+
+import com.grammatek.simaromur.App;
+
+/**
+ * Class checks for network connection changes and saves it in a flag
+ */
+public class ConnectionCheck {
+    private final static String LOG_TAG = "Simaromur_" + ConnectionCheck.class.getSimpleName();
+    private final Context context;
+
+    public static boolean isNetworkConnected() {
+        return isNetworkConnected;
+    }
+
+    private static boolean isNetworkConnected = false;
+
+    // You need to pass the context when creating the class
+    public ConnectionCheck(Context context) {
+        this.context = context;
+    }
+
+    /**
+     * Registers network callback to monitor network changes.
+     */
+    public void registerNetworkCallback()
+    {
+        try {
+            ConnectivityManager connectivityManager =
+                    (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+            connectivityManager.registerDefaultNetworkCallback(new ConnectivityManager.NetworkCallback() {
+                       @Override
+                       public void onAvailable(Network network) {
+                           // network available
+                           NetworkCapabilities nc = connectivityManager.getNetworkCapabilities(network);
+                           if (nc.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+                               Log.v(LOG_TAG, "Internet available");
+                               isNetworkConnected = true;
+                           }
+                       }
+                       @Override
+                       public void onLost(Network network) {
+                           Log.v(LOG_TAG, "Internet lost");
+                           isNetworkConnected = false;
+                       }
+                   }
+            );
+        } catch (Exception e){
+            isNetworkConnected = false;
+        }
+    }
+}

--- a/app/src/main/java/com/grammatek/simaromur/network/tiro/SpeakController.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/tiro/SpeakController.java
@@ -5,7 +5,10 @@ import android.util.Log;
 import com.grammatek.simaromur.audio.AudioObserver;
 import com.grammatek.simaromur.network.tiro.pojo.SpeakRequest;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 
 import okhttp3.ResponseBody;
 import retrofit2.Call;
@@ -108,6 +111,7 @@ public class SpeakController implements Callback<ResponseBody> {
                 Log.v(LOG_TAG, "API returned: " + data.length + " bytes");
                 mAudioObserver.update(data);
             } catch (IOException e) {
+                Log.e(LOG_TAG, "Exception: " + e.getMessage());
                 e.printStackTrace();
             }
         } else {
@@ -124,7 +128,20 @@ public class SpeakController implements Callback<ResponseBody> {
     }
 
     @Override
-    public void onFailure(Call<ResponseBody> call, Throwable t) {
-        t.printStackTrace();
+    public void onFailure(@NotNull Call<ResponseBody> call, Throwable t) {
+        String errMsg = "";
+        if (t instanceof SocketTimeoutException) {
+            errMsg = "Socket timeout";
+        } else if (t instanceof IOException) {
+            errMsg = "Timeout";
+        } else {
+            if (call.isCanceled()) {
+                errMsg = "Call was cancelled";
+            } else {
+                errMsg = "Network Error :" + t.getLocalizedMessage();
+            }
+        }
+        Log.e(LOG_TAG, "onFailure: " + errMsg);
+        mAudioObserver.error(errMsg);
     }
 }

--- a/app/src/main/java/com/grammatek/simaromur/network/tiro/VoiceController.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/tiro/VoiceController.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import com.grammatek.simaromur.network.tiro.pojo.VoiceResponse;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.List;
 
 import retrofit2.Call;
@@ -122,6 +123,19 @@ public class VoiceController implements Callback<List<VoiceResponse>> {
 
     @Override
     public void onFailure(Call<List<VoiceResponse>> call, Throwable t) {
-        t.printStackTrace();
+        String errMsg = "";
+        if (t instanceof SocketTimeoutException) {
+            errMsg = "Socket timeout";
+        } else if (t instanceof IOException) {
+            errMsg = "Timeout";
+        } else {
+            if (call.isCanceled()) {
+                errMsg = "Call was cancelled";
+            } else {
+                errMsg = "Network Error :" + t.getLocalizedMessage();
+            }
+        }
+        Log.e(LOG_TAG, "onFailure: " + errMsg);
+        mVoiceListObserver.error(errMsg);
     }
 }


### PR DESCRIPTION
`CheckSimVoices`: fix crash when no voices are registered yet.
    
- The activity could be called, before other callbacks had been fired before, resulting in mAppRepository.getCachedVoices() to return null. Add a check for null additionally to check if the voice list is empty.

`AppRepository`: Don't pre-populate voice list and fetch voice list regularly.
    
- Query Tiro API regularly for fetching current voice list every 30 minutes  while the application runs
- Don't prepopulate the data base with dummy entries

`network/ConnectionCheck`: add proper handling for internet connection check
    
- Add class ConnectionCheck that monitors the default network for internet capability
- Remove methods App.hasNetowrk() and App.hasNetwork2().
