### PR TITLE
fixed norm issues and covid

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/frontend/NormalizationDictionaries.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/NormalizationDictionaries.java
@@ -41,8 +41,8 @@ public class NormalizationDictionaries {
     public static final String THE_CLOCK = "(núll|eitt|tvö|þrjú|fjögur|fimm|sex|sjö|átta|níu|tíu|ellefu|tólf" +
             "|((þret|fjór|fimm|sex)tán)|((sau|á|ní)tján)|tuttugu( og (eitt|tvö|þrjú|fjögur))?)";
     // e.g. 12.345.678,59 or 34,5 etc. //TODO: this would match 12.345.1234556677,34 -> is this deliberate?
-    public static final String MEASURE_PREFIX_DIGITS = "(\\d{1,2}" + DOT + ")?(\\d{3}" + DOT + "?)*\\d+(,\\d+)?";
-    public static final String MEASURE_PREFIX_WORDS = "([Hh]undr[au]ð|HUNDR[AU]Ð|[Þþ]úsund|ÞÚSUND|[Mm]illjón(ir)?|MILLJÓN(IR)?) ";
+    public static final String MEASURE_PREFIX_DIGITS = "((\\d{1,2}" + DOT + ")?(\\d{3}" + DOT + ")*\\d{3}|\\d+)(,\\d+)?";
+    public static final String MEASURE_PREFIX_WORDS = "([Hh]undr[au]ð|HUNDR[AU]Ð|[Þþ]úsund|ÞÚSUND|[Mm]illjón(ir)?|MILLJÓN(IR)?)";
 
     // any number, (large, small, with or without thousand separators, with or without a decimal point) that does NOT end with a "1"
     public static final String NUMBER_EOS_NOT_1 = "(\\d{1,2}\\.)?(\\d{3}\\.?)*(\\d*[02-9]|\\d,\\d*[02-9]))";
@@ -287,8 +287,8 @@ public class NormalizationDictionaries {
         abbreviationDict.put(BOS + "([Þþ]" + DOT + "m" + DOT + "t" + DOT + "|Þ" + DOT + "M" + DOT + "T)" + DOT_ONE_NONE + EOS,
                 "$1þar með talið$3");
 
-        abbreviationDict.put(" ((" + MEASURE_PREFIX_DIGITS + "|" + MEASURE_PREFIX_WORDS + ")( )?\\s)(þú" + DOT_ONE_NONE + ")" +
-                "( " + LETTER + "*)?", "$1þúsund$11"); // changed from group 13 to 11
+        abbreviationDict.put(" (((" + MEASURE_PREFIX_DIGITS + "|" + MEASURE_PREFIX_WORDS + ")( )?)\\s)(þús" + DOT_ONE_NONE + ")" +
+                "( " + LETTER + "*)?", " $1þúsund$13");
         abbreviationDict.put(" ([Mm]örg )þús" + DOT_ONE_NONE + "( " + LETTER + "*)?", "$1þúsund$2");
 
         abbreviationDict.put("(\\d+" + DOT + ") [Áá]rg" + DOT + EOS, "$1 árgangur$2");

--- a/app/src/main/java/com/grammatek/simaromur/frontend/TTSNormalizer.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/TTSNormalizer.java
@@ -115,7 +115,7 @@ public class TTSNormalizer {
             // add space between upper case letters, if they do not build known Acronyms like "RÚV"
             else if (token.matches(NumberHelper.LETTERS_PTRN) && token.length() > 1) {
                 if (TTSUnicodeNormalizer.inDictionary(token))
-                    token = token.toLowerCase();
+                    token = processSpecialToken(token);
                 else
                     token = insertSpaces(token);
             }
@@ -150,6 +150,15 @@ public class TTSNormalizer {
             replaced = matcher.replaceAll(dict.get(regex));
         }
         return replaced;
+    }
+
+    // This is a hack to make sure we don't corrupt tokens that look like they should e.g.
+    // be space separated (COVID -> C O V I D), because we don't have direct access to the
+    // pronunciation dictionary on the server. Need a better workflow for this.
+    private String processSpecialToken(String token) {
+        if (token.toLowerCase().equals("covid"))
+            return "kovid";
+        return token.toLowerCase();
     }
 
     private String insertSpaces(String token) {

--- a/app/src/main/java/com/grammatek/simaromur/frontend/TTSUnicodeNormalizer.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/TTSUnicodeNormalizer.java
@@ -111,6 +111,12 @@ public class TTSUnicodeNormalizer {
                             // we found a replacement for the non-Icelandic character
                             if (!repl.isEmpty())
                                 wrd = wrd.replace(Character.toString(wrd.charAt(i)), repl);
+                            // sounds odd if parenthesis are ignored and don't cause the tts voice
+                            // to pause a little, try a comma
+                            // TODO: we might need a more general approach to this, i.e. which
+                            // symbols and punctuation chars should cause the voice to pause?
+                            else if (wrd.charAt(i) == '(' || wrd.charAt(i) == ')')
+                                wrd = wrd.replace(Character.toString(wrd.charAt(i)), ",");
                             // we want to keep punctuation marks still present in the normalized
                             // string, but delete the unknown character otherwise
                             else if (!Character.toString(wrd.charAt(i)).matches("\\p{Punct}"))

--- a/app/src/main/java/com/grammatek/simaromur/frontend/TTSUnicodeNormalizer.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/TTSUnicodeNormalizer.java
@@ -115,7 +115,7 @@ public class TTSUnicodeNormalizer {
                             // to pause a little, try a comma
                             // TODO: we might need a more general approach to this, i.e. which
                             // symbols and punctuation chars should cause the voice to pause?
-                            else if (wrd.charAt(i) == '(' || wrd.charAt(i) == ')')
+                            else if (wrd.charAt(i) == '(' || wrd.charAt(i) == ')' || wrd.charAt(i) == '"')
                                 wrd = wrd.replace(Character.toString(wrd.charAt(i)), ",");
                             // we want to keep punctuation marks still present in the normalized
                             // string, but delete the unknown character otherwise

--- a/app/src/main/res/raw/lexicon.txt
+++ b/app/src/main/res/raw/lexicon.txt
@@ -3904,6 +3904,7 @@ courts
 coventry
 cover
 covered
+covid
 cox
 craft
 craig

--- a/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
+++ b/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
@@ -28,11 +28,11 @@ public class NormalizationManagerTest {
 
     @Test
     public void processTest() {
-        String input = "er \uF0C9";
+        String input = "Í gær greindust 78 með COVID-19";
         NormalizationManager manager = new NormalizationManager(context);
         String processed = manager.process(input);
         System.out.println(processed);
-        assertEquals("er .",
+        assertEquals("Í gær greindust sjötíu og átta með kovid nítján .",
                 processed);
     }
 
@@ -47,6 +47,8 @@ public class NormalizationManagerTest {
 
     private Map<String, String> getTestSentences() {
         Map<String, String> testSentences = new HashMap<>();
+        testSentences.put("Í gær greindust 78 með COVID-19",
+                "Í gær greindust sjötíu og átta með kovid nítján .");
         testSentences.put("þetta stóð í 4. gr. laga.",  "þetta stóð í fjórðu grein laga .");
         testSentences.put("Að jafnaði koma daglega um 48 rútur í Bláa Lónið .",
                 "Að jafnaði koma daglega um fjörutíu og átta rútur í Bláa Lónið .");
@@ -70,7 +72,7 @@ public class NormalizationManagerTest {
         testSentences.put("Einnig er gert ráð fyrir að sameina lóðir og byggingarreiti við Sjávarbraut 1 - 7 í 1 lóð og 1 byggingarreit.   Miðaverð fyrir fullorðna kr. 5500 ",
                 "Einnig er gert ráð fyrir að sameina lóðir og byggingarreiti við Sjávarbraut eitt til sjö í einni lóð og einum byggingarreit . Miðaverð fyrir fullorðna krónur fimm þúsund og fimm hundruð .");
         testSentences.put("Stolt Sea Farm (SSF), fiskeldisarmur norsku skipa- og iðnaðarsamstæðunnar Stolt-Nielsen, jók sölu sína á flatfiski um 53% á öðrum ársfjórðungi 2015.",
-                "Stolt Sea Farm ( S S F ) , fiskeldisarmur norsku skipa og iðnaðarsamstæðunnar Stolt Nielsen , jók sölu sína á flatfiski um fimmtíu og þrjú prósent á öðrum ársfjórðungi tvö þúsund og fimmtán .");
+                "Stolt Sea Farm , S S F , , fiskeldisarmur norsku skipa og iðnaðarsamstæðunnar Stolt Nielsen , jók sölu sína á flatfiski um fimmtíu og þrjú prósent á öðrum ársfjórðungi tvö þúsund og fimmtán .");
         testSentences.put("Í janúarbyrjun 1983 var stofnað nýtt hlutafélag, Víkurféttir ehf. sem tók við.",
                 "Í janúarbyrjun nítján hundruð áttatíu og þrjú var stofnað nýtt hlutafélag , Víkurféttir E H F sem tók við .");
         testSentences.put("Jarðskjálfti að stærð 3,9 varð fyrir sunnan Kleifarvatn kl. 19:50 í gærkvöldi.",
@@ -114,7 +116,7 @@ public class NormalizationManagerTest {
         //testSentences.put("Hollenska fjárfestingafyrirtækið EsBro hyggst reisa 15 ha (150.000 m²) gróðurhús til framleiðslu á tómötum",
         //        "Hollenska fjárfestingafyrirtækið EsBro hyggst reisa fimmtán hektara ( hundrað og fimmtíu þúsund fermetra ) gróðurhús til framleiðslu á tómötum");
         testSentences.put("Hollenska fjárfestingafyrirtækið EsBro hyggst reisa 15 ha (150.000 m²) gróðurhús til framleiðslu á tómötum",
-                "Hollenska fjárfestingafyrirtækið EsBro hyggst reisa fimmtán hektarar ( hundrað og fimmtíu þúsund fermetrar ) gróðurhús til framleiðslu á tómötum .");
+                "Hollenska fjárfestingafyrirtækið EsBro hyggst reisa fimmtán hektarar , hundrað og fimmtíu þúsund fermetrar , gróðurhús til framleiðslu á tómötum .");
         testSentences.put("Mynd / elg@vf.is", "Mynd skástrik e l g hjá v f punktur is .");
         testSentences.put("hefur leikið sjö leiki með U-21 árs liðinu.", "hefur leikið sjö leiki með U tuttugu og eins árs liðinu .");
         testSentences.put("er þetta í 23. skiptið sem mótið er haldið .", "er þetta í tuttugasta og þriðja skiptið sem mótið er haldið .");
@@ -127,6 +129,8 @@ public class NormalizationManagerTest {
         // both we and regina make this error with "mínútu" instead of "mínútur"
         testSentences.put("Hann bætti Íslandsmet sitt í 5.000 m kappakstri um 11 mín.",
                 "Hann bætti Íslandsmet sitt í fimm þúsund metra kappakstri um ellefu mínútu .");
+        testSentences.put("Það er rúmlega 93 þús km",
+                "Það er rúmlega níutíu og þrjú þúsund kílómetrar .");
 
         return testSentences;
     }

--- a/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
+++ b/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
@@ -63,7 +63,7 @@ public class NormalizationManagerTest {
         testSentences.put("Af því tilefni verða kynningar um allt land á hinum ýmsu deildum innann SL þriðjudaginn 18. janúar nk. ",
                 "Af því tilefni verða kynningar um allt land á hinum ýmsu deildum innann S L þriðjudaginn átjánda janúar næstkomandi .");
         testSentences.put("„ Ég kíki daglega á facebook , karfan.is , vf.is , mbl.is , kkí , og utpabroncs.com . “ ",
-                "\" Ég kíki daglega á facebook , k a r f a n punktur is , v f punktur is , m b l punktur is , k k í , og u t p a b r o n c s punktur com . \"");
+                ", Ég kíki daglega á facebook , k a r f a n punktur is , v f punktur is , m b l punktur is , k k í , og u t p a b r o n c s punktur com . ,");
         testSentences.put("Arnór Ingvi Traustason 57. mín. Jónas Guðni, sem er 33 ára, hóf fótboltaferil sinn árið 2001.",
                 "Arnór Ingvi Traustason fimmtugasta og sjöunda mínúta . Jónas Guðni , sem er þrjátíu og þriggja ára , hóf fótboltaferil sinn árið tvö þúsund og eitt .");
         // correct version impossible, since the tagger tags "lóð" and "byggingarreit" as dative, causing "í einni lóð og einum byggingarreit" (regina original does that as well)


### PR DESCRIPTION
Fixed the issue "93 þús km", and parenthesis are now converted to ',' to enforce a pause in the speech. Also added "COVID" as a special token, so that it does not get pronunced as "C O V I D".