### PR TITLE
Fix playstore issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,7 +74,8 @@ android {
             // Android Gradle plugin.
             shrinkResources true
 
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
+                    'proguard-rules.pro', 'okio.pro', 'retrofit2.pro', 'gson.pro'
             ndk {
                 debugSymbolLevel 'full'
             }

--- a/app/gson.pro
+++ b/app/gson.pro
@@ -1,0 +1,28 @@
+##---------------Begin: proguard configuration for Gson  ----------
+# Gson uses generic type information stored in a class file when working with fields. Proguard
+# removes such information by default, so configure it to keep all of it.
+-keepattributes Signature
+
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+
+# Gson specific classes
+-dontwarn sun.misc.**
+#-keep class com.google.gson.stream.** { *; }
+
+# Application classes that will be serialized/deserialized over Gson
+-keep class com.google.gson.examples.android.model.** { <fields>; }
+
+# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
+# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+
+# Prevent R8 from leaving Data object members always null
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+
+##---------------End: proguard configuration for Gson  ----------

--- a/app/okio.pro
+++ b/app/okio.pro
@@ -1,0 +1,2 @@
+# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
+-dontwarn org.codehaus.mojo.animal_sniffer.*

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,8 +14,11 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class opennlp.** { *; }
+-dontwarn opennlp.**

--- a/app/retrofit2.pro
+++ b/app/retrofit2.pro
@@ -1,0 +1,40 @@
+# Retrofit does reflection on generic parameters. InnerClasses is required to use Signature and
+# EnclosingMethod is required to use InnerClasses.
+-keepattributes Signature, InnerClasses, EnclosingMethod
+
+# Retrofit does reflection on method and parameter annotations.
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
+
+# Keep annotation default values (e.g., retrofit2.http.Field.encoded).
+-keepattributes AnnotationDefault
+
+# Retain service method parameters when optimizing.
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Ignore JSR 305 annotations for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# Guarded by a NoClassDefFoundError try/catch and only used when on the classpath.
+-dontwarn kotlin.Unit
+
+# Top-level functions that can only be used by Kotlin.
+-dontwarn retrofit2.KotlinExtensions
+-dontwarn retrofit2.KotlinExtensions$*
+
+# With R8 full mode, it sees no subtypes of Retrofit interfaces since they are created with a Proxy
+# and replaces all potential values with null. Explicitly keeping the interfaces prevents this.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+
+# Keep generic signature of Call (R8 full mode strips signatures from non-kept items).
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,9 +4,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:name=".App"
@@ -14,8 +12,7 @@
         android:icon="@drawable/ic_launcher_app_logo"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:requestLegacyExternalStorage="true"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="false">
 
         <uses-library
             android:name="android.test.runner"

--- a/app/src/main/java/com/grammatek/simaromur/ApiDbUtil.java
+++ b/app/src/main/java/com/grammatek/simaromur/ApiDbUtil.java
@@ -70,7 +70,12 @@ public class ApiDbUtil {
             Voice voice = new Voice(av.VoiceId, av.VoiceId, av.Gender, av.LanguageCode, av.LanguageName,
                     "", Voice.TYPE_TIRO, "");
             Log.v(LOG_TAG, "New contents: " + voice);
-            mVoiceDao.insertVoice(voice);
+            try {
+                mVoiceDao.insertVoice(voice);
+            } catch (Exception e) {
+                Log.e(LOG_TAG, "Voice could not be added to db: " + voice);
+                Log.e(LOG_TAG, "Reason: " + e.getMessage());
+            }
         }
     }
 

--- a/app/src/main/java/com/grammatek/simaromur/VoiceManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceManager.java
@@ -48,6 +48,7 @@ public class VoiceManager extends AppCompatActivity {
             Log.v(LOG_TAG, "onItemClick - Selected Voice: " + voice.name);
             launchVoiceInfoActivity(voice);
         });
+        App.getAppRepository().streamTiroVoices("");
     }
 
     public void launchVoiceInfoActivity( Voice voice) {

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config>
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
     </base-config>
+    <domain-config>
+        <domain includeSubdomains="true">tts.tiro.is</domain>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Proguard: adapt rules, so that important symbols/classes are not swallowed

- Add rules for 3rdparty dependencies. In particular, OpenNLP and GSON were swallowed by ProGuard optimizations

## Security configuration updates
    
- network_security_config.xml: allow only access to tts.tiro.is
- disallow unencrypted network traffic
- take away permissions for READ_EXTERNAL_STORAGE/WRITE_EXTERNAL_STORAGE

## Catch exception when trying to update the database.
    
- When analyzing the Google play installed application, empty voice entries  were generated by the Retrofit http client in combination with GSON entries. These led to a crash, because the DB layer complained about missed non-null constrains. Catch the exception and log it.
- Additionally always request new voice list, if the VoiceManager activity is started. With that, we can trigger a network request instead of waiting until the voice update timer expired, which is currently 30 minutes.