### PR TITLE
Fix 1.0-beta3.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -149,7 +149,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.5.1"
 
     // Room
-    def room_version = "2.3.0"
+    def room_version = "2.4.0-alpha04"
 
     implementation "androidx.room:room-runtime:$room_version"
     annotationProcessor "androidx.room:room-compiler:$room_version"

--- a/app/schemas/com.grammatek.simaromur.db.ApplicationDb/2.json
+++ b/app/schemas/com.grammatek.simaromur.db.ApplicationDb/2.json
@@ -1,0 +1,186 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "3193313e205498f4bdfc2f29a81b63b5",
+    "entities": [
+      {
+        "tableName": "voice_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`voiceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `gender` TEXT NOT NULL, `internal_name` TEXT NOT NULL, `language_code` TEXT NOT NULL, `language_name` TEXT NOT NULL, `variant` TEXT NOT NULL, `type` TEXT, `update_time` TEXT, `download_time` TEXT, `url` TEXT, `download_path` TEXT, `version` TEXT, `md5_sum` TEXT, `local_size` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "voiceId",
+            "columnName": "voiceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gender",
+            "columnName": "gender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalName",
+            "columnName": "internal_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "languageCode",
+            "columnName": "language_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "languageName",
+            "columnName": "language_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "variant",
+            "columnName": "variant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "updateTime",
+            "columnName": "update_time",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadPath",
+            "columnName": "download_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "md5Sum",
+            "columnName": "md5_sum",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "local_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "voiceId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_voice_table_internal_name_gender_language_code_type",
+            "unique": true,
+            "columnNames": [
+              "internal_name",
+              "gender",
+              "language_code",
+              "type"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_voice_table_internal_name_gender_language_code_type` ON `${TABLE_NAME}` (`internal_name`, `gender`, `language_code`, `type`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "app_data_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`appDataId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `schema_version` TEXT, `current_voice_id` INTEGER NOT NULL, `flite_voice_list_path` TEXT, `flite_voice_list_update_time` TEXT, `sim_voice_list_path` TEXT, `sim_voice_list_update_time` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "appDataId",
+            "columnName": "appDataId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schemaVersion",
+            "columnName": "schema_version",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "currentVoiceId",
+            "columnName": "current_voice_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fliteVoiceListPath",
+            "columnName": "flite_voice_list_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fliteVoiceListUpdateTime",
+            "columnName": "flite_voice_list_update_time",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "simVoiceListPath",
+            "columnName": "sim_voice_list_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "simVoiceListUpdateTime",
+            "columnName": "sim_voice_list_update_time",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "appDataId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3193313e205498f4bdfc2f29a81b63b5')"
+    ]
+  }
+}

--- a/app/src/main/java/com/grammatek/simaromur/AppRepository.java
+++ b/app/src/main/java/com/grammatek/simaromur/AppRepository.java
@@ -59,10 +59,14 @@ public class AppRepository {
         public TiroVoiceQueryObserver() {}
         public void update(List<VoiceResponse> voices) {
             for (VoiceResponse voice: voices) {
+                if (voice == null) {
+                    Log.e(LOG_TAG, "Tiro API returned null voice ?!");
+                    return;
+                }
                 Log.v(LOG_TAG, "Tiro API returned: " + voice.VoiceId);
             }
             mTiroVoices = voices;
-            new updateVoicesAsyncTask(mApiDbUtil).execute(mTiroVoices);
+            new updateVoicesAsyncTask(mApiDbUtil, "tiro").execute(mTiroVoices);
             new updateAppDataVoiceListTimestampAsyncTask(mAppDataDao).execute();
         }
         public void error(String errorMsg) {
@@ -414,12 +418,16 @@ public class AppRepository {
 
     private static class updateVoicesAsyncTask extends AsyncTask<List<VoiceResponse>, Void, Void> {
         private ApiDbUtil mApiDbUtil;
+        private String mVoiceType;
 
-        updateVoicesAsyncTask(ApiDbUtil apiDbUtil) {  mApiDbUtil = apiDbUtil;  }
+        updateVoicesAsyncTask(ApiDbUtil apiDbUtil, String voiceType) {
+            mApiDbUtil = apiDbUtil;
+            mVoiceType = voiceType;
+        }
 
         @Override
         protected Void doInBackground(final List<VoiceResponse>... voices) {
-            mApiDbUtil.updateModelVoices(voices[0]);
+            mApiDbUtil.updateApiVoices(voices[0], mVoiceType);
             return null;
         }
     }

--- a/app/src/main/java/com/grammatek/simaromur/db/ApplicationDb.java
+++ b/app/src/main/java/com/grammatek/simaromur/db/ApplicationDb.java
@@ -5,6 +5,7 @@ import android.os.AsyncTask;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.room.AutoMigration;
 import androidx.room.Database;
 import androidx.room.Room;
 import androidx.room.RoomDatabase;
@@ -14,8 +15,14 @@ import com.grammatek.simaromur.App;
 
 import java.util.List;
 
-@Database(entities = {Voice.class, AppData.class},
-        version = 1, exportSchema = true)
+@Database(
+        version = 2,
+        entities = {Voice.class, AppData.class},
+        exportSchema = true,
+        autoMigrations = {
+            @AutoMigration(from = 1, to = 2)
+        }
+)
 public abstract class ApplicationDb extends RoomDatabase {
     private final static String LOG_TAG = "Simaromur_" + ApplicationDb.class.getSimpleName();
     private static ApplicationDb INSTANCE;

--- a/app/src/main/java/com/grammatek/simaromur/db/Voice.java
+++ b/app/src/main/java/com/grammatek/simaromur/db/Voice.java
@@ -17,9 +17,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
-// Create unique index on name, language, country, variant
+// Create unique index
 @Entity(tableName = "voice_table",
-        indices = {@Index(value = {"name", "gender", "language_code", "type"}, unique = true)})
+        indices = {@Index(value = {"internal_name", "gender", "language_code", "type"}, unique = true)})
 public class Voice {
     private final static String LOG_TAG = "Voice" + CheckSimVoices.class.getSimpleName();
     public final static String TYPE_TIRO="tiro";

--- a/app/src/main/java/com/grammatek/simaromur/db/VoiceDao.java
+++ b/app/src/main/java/com/grammatek/simaromur/db/VoiceDao.java
@@ -23,7 +23,7 @@ public interface VoiceDao {
     @Delete
     void deleteVoices(Voice... voices);
 
-    @Query("SELECT * FROM voice_table")
+    @Query("SELECT * FROM voice_table as voices order by voices.internal_name asc")
     public LiveData<List<Voice>> getAllVoices();
 
     /**


### PR DESCRIPTION
## ApplicationDb/Voice schema: use different properties for index on Voice entity
    
- Use `Voice.internal_name` instead of `Voice.name` for the index, because that is what makes a voice uniquely identifiable on the API level
- Use Room's new automigration feature, add room `2.4-alpha04` as necessary dependency

## ApiDbUtil.updateApiVoices: remove voices from DB if no longer provided
    
- in case the returned Voice list is valid and doesn't contain previously reported voices, remove all invalidated voices from Db
- in case, a voice is deserialized as being null, don't do any updates and log an error instead
- apply additional checks of the voice type before doing any destructive operations

## VoiceDao.getAllVoices(): order returned voices by name in ascending order
- This will also show the list of voices in VoiceManager sorted.

This MR closes https://github.com/grammatek/simaromur/issues/53 and closes https://github.com/grammatek/simaromur/issues/52