### PR TITLE
Fix firebase crashreport1

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/TTSObserver.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSObserver.java
@@ -61,7 +61,7 @@ public class TTSObserver implements AudioObserver {
     }
 
     public void stop() {
-        if (mSynthCb.hasStarted()) {
+        if (mSynthCb.hasStarted() && ! mSynthCb.hasFinished()) {
             mSynthCb.done();
         }
     }

--- a/app/src/main/java/com/grammatek/simaromur/TTSService.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSService.java
@@ -101,7 +101,7 @@ public class TTSService extends TextToSpeechService {
                 Log.w(LOG_TAG, "onSynthesizeText: couldn't load voice ("+voiceNameToLoad+")");
                 callback.start(SAMPLE_RATE_WAV, AudioFormat.ENCODING_PCM_16BIT, N_CHANNELS);
                 callback.error(ERROR_SERVICE);
-                if (callback.hasStarted()) {
+                if (callback.hasStarted() && ! callback.hasFinished()) {
                     callback.done();
                 }
                 return;
@@ -146,7 +146,7 @@ public class TTSService extends TextToSpeechService {
         callback.start(SAMPLE_RATE_WAV, AudioFormat.ENCODING_PCM_16BIT, 1);
         byte[] silenceData = new byte[callback.getMaxBufferSize()/2];
         callback.audioAvailable(silenceData, 0, silenceData.length);
-        if (callback.hasStarted()) {
+        if (callback.hasStarted() && ! callback.hasFinished()) {
             callback.done();
         }
     }

--- a/app/src/main/java/com/grammatek/simaromur/network/tiro/VoiceController.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/tiro/VoiceController.java
@@ -4,6 +4,8 @@ import android.util.Log;
 
 import com.grammatek.simaromur.network.tiro.pojo.VoiceResponse;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.List;
@@ -62,8 +64,6 @@ public class VoiceController implements Callback<List<VoiceResponse>> {
         if (mCall != null) {
             mCall.cancel();
         }
-        mCall = null;
-        mVoiceListObserver = null;
     }
 
     /**
@@ -108,7 +108,7 @@ public class VoiceController implements Callback<List<VoiceResponse>> {
     }
 
     @Override
-    public synchronized void onResponse(Call<List<VoiceResponse>> call, Response<List<VoiceResponse>> response) {
+    public synchronized void onResponse(@NotNull Call<List<VoiceResponse>> call, Response<List<VoiceResponse>> response) {
         assert (mVoiceListObserver != null);
         if(response.isSuccessful()) {
             List<VoiceResponse> voicesList = response.body();
@@ -122,20 +122,14 @@ public class VoiceController implements Callback<List<VoiceResponse>> {
     }
 
     @Override
-    public void onFailure(Call<List<VoiceResponse>> call, Throwable t) {
-        String errMsg = "";
-        if (t instanceof SocketTimeoutException) {
-            errMsg = "Socket timeout";
-        } else if (t instanceof IOException) {
-            errMsg = "Timeout";
-        } else {
+    public void onFailure(@NotNull Call<List<VoiceResponse>> call, Throwable t) {
+        Log.v(LOG_TAG, "onFailure: " + t.getLocalizedMessage());
+        assert (mVoiceListObserver != null);
+        if (t instanceof IOException) {
             if (call.isCanceled()) {
-                errMsg = "Call was cancelled";
-            } else {
-                errMsg = "Network Error :" + t.getLocalizedMessage();
+                return;
             }
         }
-        Log.e(LOG_TAG, "onFailure: " + errMsg);
-        mVoiceListObserver.error(errMsg);
+        mVoiceListObserver.error(t.getLocalizedMessage());
     }
 }


### PR DESCRIPTION
## TTS callbacks: only call done() if !callback.hasFinished()
    
Observing messages in LogCat like "Duplicate call to done()". The sequence order for `start()`/`done()` is very important in Android TTS, as TTS clients are basing their internal states on the correct order of execution.
    
So now we not only check, if the callback has already been started before calling done(), we additionally check, if `callback.done()` hasn't already been called before.

## SpeakController/VoiceController: fix bug reported in Firebase
    
When calling `stop()`, ongoing calls were cancelled and the observers and Retrofit calls were nulled. But the callbacks onFailure() method is nevertheless executed from Retrofit as a consequence of calling `call.cancel()`. Therefore, we got a NPE when trying to access the observers `error()` method inside `onFailure()`.
    
The solution implemented in this commit doesn't null the calls anymore and simplifies the `onFailure()` methods to their bare minimum. In case the call is cancelled, no observer `error()` method is called.
    
This behaviour can be tested by using the Screen-Reader and rapidly skipping the currently played Screenpart to the next section.

Closes https://github.com/grammatek/simaromur/issues/56
