### PR TITLE
ApplicationDB: replace AutoMigration with a manual migration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,15 @@ android {
         }
     }
 
+    sourceSets {
+        project.logger.lifecycle('$projectDir/schemas: ' + "$projectDir/schemas".toString())
+        androidTest.assets.srcDirs +=
+                files("$projectDir/schemas".toString())
+        debug.assets.srcDirs +=
+                files("$projectDir/schemas".toString())
+        release.assets.srcDirs +=
+                files("$projectDir/schemas".toString())
+    }
     buildTypes {
 
         release {
@@ -140,6 +149,8 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test:core:1.4.0'
+    testImplementation 'androidx.test:core-ktx:1.4.0'
+    testImplementation 'androidx.test.ext:junit-ktx:1.1.3'
     testImplementation 'org.mockito:mockito-core:1.10.19'
     testImplementation 'com.google.truth:truth:1.0'
 

--- a/app/src/test/java/com/grammatek/simaromur/TestRoomDbMigration.java
+++ b/app/src/test/java/com/grammatek/simaromur/TestRoomDbMigration.java
@@ -1,0 +1,88 @@
+package com.grammatek.simaromur;
+
+import androidx.room.AutoMigration;
+import androidx.room.testing.MigrationTestHelper;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.grammatek.simaromur.db.ApplicationDb;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * ERoom database migration tests
+ *
+ */
+@RunWith(AndroidJUnit4.class)
+public class TestRoomDbMigration {
+
+    private final String TEST_DB_NAME="simaromur-test";
+
+    @Rule
+    public MigrationTestHelper testHelper;
+
+    public TestRoomDbMigration() {
+        testHelper = new MigrationTestHelper((InstrumentationRegistry.getInstrumentation()),
+                ApplicationDb.class.getCanonicalName(), new FrameworkSQLiteOpenHelperFactory());
+    }
+
+    @Test
+    public void migrationFrom1To2() throws IOException {
+        // Create the database in version 1
+        SupportSQLiteDatabase db =
+                testHelper.createDatabase(TEST_DB_NAME, 1);
+        db.execSQL("INSERT INTO app_data_table VALUES (1, '1', 2, '/flite/voices', 'today'," +
+                " '/sim/voices', 'today')");
+
+        db.execSQL("INSERT INTO voice_table VALUES (1, 'Álfur', 'male', 'Alfur', 'is-IS', 'Íslenska(icelandic)'," +
+                " '', 'tiro', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
+        db.execSQL("INSERT INTO voice_table VALUES (3, 'Dóra', 'female', 'Dora', 'is-IS', 'Íslenska(icelandic)'," +
+                " '', 'tiro', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
+        // index is just created on name, internal_name may be redundant. That's why schema v2 was created
+        db.execSQL("INSERT INTO voice_table VALUES (2, 'Alfur', 'male', 'Alfur', 'is-IS', 'Íslenska(icelandic)'," +
+                " '', 'tiro', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
+        db.execSQL("INSERT INTO voice_table VALUES (4, 'Dora', 'female', 'Dora', 'is-IS', 'Íslenska(icelandic)'," +
+                " '', 'tiro', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
+        db.close();
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 2, true, ApplicationDb.MIGRATION_1_2);
+    }
+
+    @Test
+    public void TestDBV2() throws IOException {
+        // Create DB in V2
+        SupportSQLiteDatabase db =
+                testHelper.createDatabase(TEST_DB_NAME, 2);
+        db.execSQL("INSERT INTO app_data_table VALUES (1, '1', 2, '/flite/voices', 'today'," +
+                " '/sim/voices', 'today')");
+
+        db.execSQL("INSERT INTO voice_table VALUES (1, 'Álfur', 'male', 'Alfur', 'is-IS', 'Íslenska(icelandic)'," +
+                " '', 'tiro', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
+        db.execSQL("INSERT INTO voice_table VALUES (2, 'Dóra', 'female', 'Dora', 'is-IS', 'Íslenska(icelandic)'," +
+                " '', 'tiro', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
+
+        try {
+            // try to add a bunch of redundant entries: unique index constraint for internal name
+            // is then violated
+            db.execSQL("INSERT INTO voice_table VALUES (3, 'Alfur', 'male', 'Alfur', 'is-IS', 'Íslenska(icelandic)'," +
+                    " '', 'tiro', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
+            db.execSQL("INSERT INTO voice_table VALUES (4, 'Dora', 'female', 'Dora', 'is-IS', 'Íslenska(icelandic)'," +
+                    " '', 'tiro', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
+            fail("Exception not thrown");
+        }
+        catch (Exception e) {
+            // nothing
+        }
+
+        db.close();
+    }
+}


### PR DESCRIPTION
Firebase shows a migration error from version 1 -> 2 on some devices. This happens when a previously saved voice table contains multiple entries with the same `internal_name`. This could happen, because in `V1` we used the wrong attribute for the table index on `name` instead of `internal_name`. When Tiro changed some voice names to contain Icelandic characters, multiple entries are stored inside the DB and auto migration to V2 fails because of violation of the uniquness of `internal_name`.

Therefore, we add a destructive manual migration step for v1 -> v2, by dropping the previous unique index and the voice table altogether and recreate the table and the new index via SQL statements.

Added also a migration unit test case and the appropriate build dependencies.