### PR TITLE
fixed abbrDict regex

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/frontend/NormalizationDictionaries.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/NormalizationDictionaries.java
@@ -287,8 +287,8 @@ public class NormalizationDictionaries {
         abbreviationDict.put(BOS + "([Þþ]" + DOT + "m" + DOT + "t" + DOT + "|Þ" + DOT + "M" + DOT + "T)" + DOT_ONE_NONE + EOS,
                 "$1þar með talið$3");
 
-        abbreviationDict.put(" (((" + MEASURE_PREFIX_DIGITS + "|" + MEASURE_PREFIX_WORDS + ")( )?)\\s)(þús" + DOT_ONE_NONE + ")" +
-                "( " + LETTER + "*)?", " $1þúsund$13");
+        abbreviationDict.put(" (((" + MEASURE_PREFIX_DIGITS + "|" + MEASURE_PREFIX_WORDS + ")( )?)\\s)(þús" + DOT_ONE_NONE + " )" +
+                "(" + LETTER + "*)?", " $1þúsund $13");
         abbreviationDict.put(" ([Mm]örg )þús" + DOT_ONE_NONE + "( " + LETTER + "*)?", "$1þúsund$2");
 
         abbreviationDict.put("(\\d+" + DOT + ") [Áá]rg" + DOT + EOS, "$1 árgangur$2");

--- a/app/src/main/java/com/grammatek/simaromur/frontend/TTSNormalizer.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/TTSNormalizer.java
@@ -47,10 +47,10 @@ public class TTSNormalizer {
             normalized = replaceFromDict(normalized, NormalizationDictionaries.directionDict);
             normalized = replaceFromDict(normalized, NormalizationDictionaries.hyphenDict);
         }
-        // most standard abbreviations
-        if (normalized.contains(".")) {
-            normalized = replaceFromDict(normalized, NormalizationDictionaries.abbreviationDict);
-        }
+        // most standard abbreviations - they don't necessarily contain a dot, so all sentences
+        // are tested for abbreviations
+        normalized = replaceFromDict(normalized, NormalizationDictionaries.abbreviationDict);
+
         // looking for patterns like "500 kr/kg"
         if (normalized.contains("/")) {
             normalized = replaceFromDict(normalized, NormalizationDictionaries.denominatorDict);

--- a/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
+++ b/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
@@ -28,11 +28,11 @@ public class NormalizationManagerTest {
 
     @Test
     public void processTest() {
-        String input = "Í gær greindust 78 með ABCD-19";
+        String input = "Það er rúmlega 93 þús km";
         NormalizationManager manager = new NormalizationManager(context);
         String processed = manager.process(input);
         System.out.println(processed);
-        assertEquals("Í gær greindust sjötíu og átta með a b c d nítján .",
+        assertEquals("gjörgæslurúm per hundrað þúsund íbúa .",
                 processed);
     }
 
@@ -139,6 +139,7 @@ public class NormalizationManagerTest {
                 "Hann bætti Íslandsmet sitt í fimm þúsund metra kappakstri um ellefu mínútu .");
         testSentences.put("Það er rúmlega 93 þús km",
                 "Það er rúmlega níutíu og þrjú þúsund kílómetrar .");
+        testSentences.put("gjörgæslurúm per hundrað þúsund íbúa", "gjörgæslurúm per hundrað þúsund íbúa .");
 
         return testSentences;
     }


### PR DESCRIPTION
Normalization error on-device: "gjörgæslurúm per hundrað þúsund íbúa" -> "gjörgæslurúm per hundrað þúsundhundrað þrírund íbúa". Could not reproduce directly, got: "gjörgæslurúm per hundrað þúsundund íbúa".
Fixed the respective regex in the abbreviation dictionary, adding spaces so that the abbreviation "þús" does not match "þúsund". Also removed the test for "dot" before sending a sentence into abbreviation check, since abbreviation do not always contain a dot, e.g. "þúsund" can be abbreviated "þús." or just "þús"