### PR TITLE
Remove bogus mAudioObserver.stop();

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/network/tiro/SpeakController.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/tiro/SpeakController.java
@@ -109,7 +109,6 @@ public class SpeakController implements Callback<ResponseBody> {
                 byte[] data = body.bytes();
                 Log.v(LOG_TAG, "API returned: " + data.length + " bytes");
                 mAudioObserver.update(data);
-                mAudioObserver.stop();
             } catch (IOException e) {
                 Log.e(LOG_TAG, "Exception: " + e.getMessage());
                 e.printStackTrace();


### PR DESCRIPTION
Don't know exactly, why this has been added, but we definitely have to
remove this line, because MediaPlayer is playing the files asynchronously
and this would already stop playing audio before it has started.

Closes #66 