### PR TITLE
normalization issues fixed

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/frontend/FrontendManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/FrontendManager.java
@@ -35,9 +35,13 @@ public class FrontendManager {
      * @return an X-SAMPA transcription of @text
      */
     public String process(String text) {
-        final String sp = " " + SymbolsLvLIs.SymbolShortPause + " ";
         final String normalized = mNormalizationManager.process(text);
-        String transcribedText = mPronunciation.transcribe(normalized);
+        return transcribe(normalized);
+    }
+
+    public String transcribe(String text) {
+        final String sp = " " + SymbolsLvLIs.SymbolShortPause + " ";
+        String transcribedText = mPronunciation.transcribe(text);
 
         // replace special characters
         transcribedText = transcribedText.replaceAll("\\.", sp);

--- a/app/src/main/java/com/grammatek/simaromur/frontend/NormalizationDictionaries.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/NormalizationDictionaries.java
@@ -233,7 +233,7 @@ public class NormalizationDictionaries {
                 + DOT_ONE_NONE + EOS, "$1og þess háttar$3");
         abbreviationDict.put(BOS + "([Oo]" + DOT_ONE_NONE + "þ" + DOT_ONE_NONE + "u" + DOT_ONE_NONE + "l|O" + DOT_ONE_NONE + "Þ"
                 + DOT_ONE_NONE + "U" + DOT_ONE_NONE + "L)" + DOT_ONE_NONE + EOS, "$1og því um líkt$3");
-        abbreviationDict.put(BOS + "([Pp]" + DOT_ONE_NONE + ")" + EOS, "$1pakki$3");
+        abbreviationDict.put(BOS + "([Pp]k" + DOT_ONE_NONE + ")" + EOS, "$1pakki$3");
 
         abbreviationDict.put(BOS + "([Rr]n" + DOT_ONE_NONE + ")(:| [\\d\\-]+)" + EOS, "$1reikningsnúmer$3$4");
         abbreviationDict.put(BOS + "([Rr]itstj" + DOT_ONE_NONE + ")" + EOS, "$1ritstjóri$3");

--- a/app/src/main/java/com/grammatek/simaromur/frontend/Pronunciation.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/Pronunciation.java
@@ -37,7 +37,7 @@ public class Pronunciation {
                 sb.append(mPronDict.get(tok).getTranscript()).append(" ");
             }
             else if (tok.equals(mSilToken)){
-                sb.append(SymbolsLvLIs.SymbolSilence).append(" ");
+                sb.append(SymbolsLvLIs.SymbolShortPause).append(" ");
             }
             else {
                 sb.append(mG2P.process(tok)).append(" ");

--- a/app/src/main/java/com/grammatek/simaromur/frontend/Pronunciation.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/Pronunciation.java
@@ -5,6 +5,7 @@ import android.content.res.Resources;
 
 import com.grammatek.simaromur.device.NativeG2P;
 import com.grammatek.simaromur.R;
+import com.grammatek.simaromur.device.SymbolsLvLIs;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -20,6 +21,7 @@ public class Pronunciation {
     private final Context mContext;
     private NativeG2P mG2P;
     private Map<String, PronDictEntry> mPronDict;
+    private String mSilToken = "<sil>";
 
     public Pronunciation(Context context) {
         this.mContext = context;
@@ -33,7 +35,11 @@ public class Pronunciation {
         for (String tok : tokens) {
             if (mPronDict.containsKey(tok)) {
                 sb.append(mPronDict.get(tok).getTranscript()).append(" ");
-            } else {
+            }
+            else if (tok.equals(mSilToken)){
+                sb.append(SymbolsLvLIs.SymbolSilence).append(" ");
+            }
+            else {
                 sb.append(mG2P.process(tok)).append(" ");
             }
         }

--- a/app/src/main/java/com/grammatek/simaromur/frontend/TTSUnicodeNormalizer.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/TTSUnicodeNormalizer.java
@@ -103,6 +103,11 @@ public class TTSUnicodeNormalizer {
             StringBuilder sb = new StringBuilder();
             String[] sentArr = sent.split(" ");
             for (String wrd : sentArr) {
+                if (isTag(wrd)) {
+                    sb.append(wrd + " ");
+                    continue;
+                }
+                //TODO: update lexicon!!
                 if (!inDictionary(wrd)) {
                     for (int i = 0; i < wrd.length(); i++) {
                         // is it an Icelandic character?
@@ -117,9 +122,14 @@ public class TTSUnicodeNormalizer {
                             // symbols and punctuation chars should cause the voice to pause?
                             else if (wrd.charAt(i) == '(' || wrd.charAt(i) == ')' || wrd.charAt(i) == '"')
                                 wrd = wrd.replace(Character.toString(wrd.charAt(i)), ",");
+                            // for now, replace end of sentence symbols with a full stop,
+                            // later the exclamation mark and question mark might have a special
+                            // meaning for the TTS engine
+                            else if (Character.toString(wrd.charAt(i)).matches("[:!?]"))
+                                wrd = wrd.replace(Character.toString(wrd.charAt(i)), ".");
                             // we want to keep punctuation marks still present in the normalized
                             // string, but delete the unknown character otherwise
-                            else if (!Character.toString(wrd.charAt(i)).matches("[.,:!?]"))
+                            else if (!Character.toString(wrd.charAt(i)).matches("[.,]"))
                                 wrd = wrd.replace(Character.toString(wrd.charAt(i)), "");
                         }
                     }
@@ -137,6 +147,10 @@ public class TTSUnicodeNormalizer {
 
     public static boolean inDictionary(String wrd) {
         return mLexicon.contains(wrd.toLowerCase());
+    }
+
+    private boolean isTag(String wrd) {
+        return wrd.matches("^<\\w+>$");
     }
 
     private boolean shouldDelete(Character c) {

--- a/app/src/main/java/com/grammatek/simaromur/frontend/TTSUnicodeNormalizer.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/TTSUnicodeNormalizer.java
@@ -107,7 +107,6 @@ public class TTSUnicodeNormalizer {
                     sb.append(wrd + " ");
                     continue;
                 }
-                //TODO: update lexicon!!
                 if (!inDictionary(wrd)) {
                     for (int i = 0; i < wrd.length(); i++) {
                         // is it an Icelandic character?

--- a/app/src/main/java/com/grammatek/simaromur/frontend/UnicodeMaps.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/UnicodeMaps.java
@@ -185,6 +185,8 @@ public class UnicodeMaps {
         otherSubstMap.put('\u0091', "'"); // private use one -> why this substitution?
         otherSubstMap.put('\u0092', "’"); // private use two -> why this substitution?
         otherSubstMap.put('\u0096', "-"); // start of guarded area -> why this substitution?
+        otherSubstMap.put('\u00a9', "höfundarréttur"); // © copyright sign
+        otherSubstMap.put('\u00ae', "skráð vörumerki"); // ® registered trademark symbol
         otherSubstMap.put('\u00b4', "'"); // acute accent
         otherSubstMap.put('\u2010', "-"); // hyphen
         otherSubstMap.put('\u2011', "-"); // non-breaking hyphen

--- a/app/src/main/res/raw/ice_pron_dict_standard_clear_2201_extended.csv
+++ b/app/src/main/res/raw/ice_pron_dict_standard_clear_2201_extended.csv
@@ -19190,6 +19190,7 @@ impact	I m p_h a x t
 implant	I m p_h l a n_0 t
 impregilo	I: m p_h r E c i l O
 impressjónismi	I m p_h r E s j ou n I s m I
+improve	I m p_h r u: v
 impru	I m_0 p r Y
 in	I n
 inc	i N k

--- a/app/src/main/res/raw/lexicon_v2201.txt
+++ b/app/src/main/res/raw/lexicon_v2201.txt
@@ -1,4 +1,5 @@
 &
+a
 a-moll
 aalesund
 aaron
@@ -2049,6 +2050,7 @@ aðvífandi
 aðvörun
 aþena
 aþenu
+b
 b-moll
 ba
 babel
@@ -5114,6 +5116,7 @@ býtum
 býð
 býðst
 býður
+c
 c-moll
 ca
 cab
@@ -5416,6 +5419,7 @@ cycles
 cycling
 cyrus
 cís-moll
+d
 d'or
 d-moll
 dabbi
@@ -6826,6 +6830,7 @@ dýrustu
 dýrð
 dýrðarhnoss
 dýrðir
+e
 e-moll
 e-pilla
 e-pillan
@@ -8518,6 +8523,7 @@ eðvaldsson
 eðvarð
 eðvarðsson
 eþíópíu
+f
 f-moll
 fabian
 fabio
@@ -12493,6 +12499,7 @@ fúsum
 fýlu
 fýlusvip
 fýsn
+g
 g-moll
 gaal
 gabb
@@ -14800,6 +14807,7 @@ gústav
 gústavsson
 gústi
 gýgur
+h
 h-moll
 ha
 haag
@@ -19107,6 +19115,7 @@ hýsa
 hýsir
 hýst
 hýsti
+i
 i'd
 i'll
 i've
@@ -19578,6 +19587,7 @@ iðrun
 iðulega
 iðunn
 iðunnar
+j
 ja
 jack
 jackson
@@ -22891,6 +22901,7 @@ kýr
 kýrnar
 kýs
 l
+l
 labb
 labba
 labbandi
@@ -25535,6 +25546,7 @@ lýðveldi
 lýðveldinu
 lýðveldisins
 lýðveldið
+m
 mac
 machine
 macro
@@ -28271,6 +28283,7 @@ mývatn
 mývatni
 mývatns
 mývatnssveit
+n
 nachos
 nadal
 nafar
@@ -29379,6 +29392,7 @@ nýyrðasmíð
 nýárs
 nýársdag
 nýútkominni
+o
 obama
 obb
 obbann
@@ -29809,6 +29823,7 @@ own
 owned
 owners
 oxford
+p
 pabba
 pabbar
 pabbarnir
@@ -30978,6 +30993,7 @@ púða
 púði
 púður
 pýþagóras
+q
 quality
 quattro
 que
@@ -30991,6 +31007,7 @@ quiet
 quite
 quiz
 quo
+r
 rabba
 rabbaði
 rabbi
@@ -32841,6 +32858,7 @@ rýrnað
 rýrnun
 rýrt
 rýrð
+s
 saari
 sabbath
 sachs
@@ -39632,6 +39650,7 @@ sýslumaður
 sýslumaðurinn
 sýslumenn
 sýslunni
+t
 table
 tabú
 taco
@@ -41479,6 +41498,7 @@ týnt
 týpa
 týr
 týra
+u
 u.s.
 uber
 ubs
@@ -42246,6 +42266,7 @@ utanyfirgöllum
 utanyfirgöllunum
 utd
 uxu
+v
 vaart
 vafa
 vafalaust
@@ -44578,6 +44599,7 @@ vöxturinn
 vöðva
 vöðvi
 vöðvum
+w
 waage
 wade
 wage
@@ -44731,9 +44753,11 @@ written
 wrong
 wrote
 wuhan
+x
 xavi
 xhaka
 xi
+y
 yahoo
 yard
 yasser
@@ -44908,6 +44932,7 @@ ytra
 ytri
 yðar
 yður
+z
 zagreb
 zeit
 zeppelin
@@ -45970,6 +45995,7 @@ zuckerberg
 æðsti
 æðstu
 æðum
+é
 ég
 éljagangur
 éljum
@@ -46295,6 +46321,7 @@ zuckerberg
 íþróttir
 íþróttum
 íþyngjandi
+ð
 ó
 óalgengt
 óaðlaðandi
@@ -46859,6 +46886,7 @@ zuckerberg
 óþökk
 óþörf
 óþörfu
+ö
 öbí
 öfga
 öfgamenn
@@ -47110,6 +47138,7 @@ zuckerberg
 öðru
 öðrum
 öðruvísi
+ú
 úff
 úganda
 úkraína
@@ -47474,6 +47503,7 @@ zuckerberg
 útúr
 útþenslu
 úði
+ý
 ýja
 ýjað
 ýkt
@@ -47504,6 +47534,7 @@ zuckerberg
 ýtrustu
 ýtt
 ýtti
+þ
 þagga
 þagna
 þagnarskyldu

--- a/app/src/main/res/raw/lexicon_v2201.txt
+++ b/app/src/main/res/raw/lexicon_v2201.txt
@@ -19190,6 +19190,7 @@ impact
 implant
 impregilo
 impressjónismi
+improve
 impru
 in
 inc

--- a/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
+++ b/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
@@ -28,12 +28,21 @@ public class NormalizationManagerTest {
 
     @Test
     public void processTest() {
-        String input = "Í gær greindust 78 með ABCD-19";
+        String input = "til áramóta 2021/2022";
         NormalizationManager manager = new NormalizationManager(context);
         String processed = manager.process(input);
         System.out.println(processed);
-        assertEquals("í gær greindust sjötíu og átta með a b c d nítján .",
+        assertEquals("til áramóta tvö þúsund tuttugu og eitt <sil> tvö þúsund tuttugu og tvö .",
                 processed);
+    }
+
+    @Test
+    public void processNewIssuesTest() {
+        NormalizationManager manager = new NormalizationManager(context);
+        for (String sent : getNewTestSentences().keySet()) {
+            String processed = manager.process(sent);
+            assertEquals(getNewTestSentences().get(sent), processed);
+        }
     }
 
     @Test
@@ -45,14 +54,22 @@ public class NormalizationManagerTest {
         }
     }
 
+    private Map<String, String> getNewTestSentences() {
+        Map<String, String> sent = new HashMap<>();
+        sent.put("Mörk Ómars á EM:", "mörk ómars á em .");
+        sent.put("til áramóta 2021/2022", "til áramóta tvö þúsund tuttugu og eitt <sil> tvö þúsund tuttugu og tvö .");
+        sent.put("© grammatek", "höfundarréttur grammatek .");
+        return sent;
+    }
+
     private Map<String, String> getTestSentences() {
         Map<String, String> testSentences = new HashMap<>();
         testSentences.put("Í gær greindust 78 með COVID-19",
-                "Í gær greindust sjötíu og átta með kovid nítján .".toLowerCase());
+                "Í gær greindust sjötíu og átta með covid nítján .".toLowerCase());
         testSentences.put("Í gær greindust 78 með Covid-19",
-                "Í gær greindust sjötíu og átta með Kovid nítján .".toLowerCase());
+                "Í gær greindust sjötíu og átta með Covid nítján .".toLowerCase());
         testSentences.put("Í gær greindust 78 með covid-19",
-                "Í gær greindust sjötíu og átta með kovid nítján .".toLowerCase());
+                "Í gær greindust sjötíu og átta með covid nítján .".toLowerCase());
         testSentences.put("Í gær greindust 78 með CREW-19",
                 "Í gær greindust sjötíu og átta með crew nítján .".toLowerCase());
         testSentences.put("Í gær greindust 78 með ABCD-19",
@@ -67,7 +84,7 @@ public class NormalizationManagerTest {
         testSentences.put("Viðeignin fer fram í sal FS og hefst klukkan 20 .",
                 "Viðeignin fer fram í sal f s og hefst klukkan tuttugu .".toLowerCase()); // spelling error!
         testSentences.put("Annars var verði 3500 fyrir tímann !",
-                "Annars var verði þrjú þúsund og fimm hundruð fyrir tímann !".toLowerCase()); // spelling error
+                "Annars var verði þrjú þúsund og fimm hundruð fyrir tímann .".toLowerCase()); // spelling error
         testSentences.put("Af því tilefni verða kynningar um allt land á hinum ýmsu deildum innann SL þriðjudaginn 18. janúar nk. ",
                 "Af því tilefni verða kynningar um allt land á hinum ýmsu deildum innann s l þriðjudaginn átjánda janúar næstkomandi .".toLowerCase());
         testSentences.put("„ Ég kíki daglega á facebook , karfan.is , vf.is , mbl.is , kkí , og utpabroncs.com . “ ",
@@ -143,6 +160,9 @@ public class NormalizationManagerTest {
         testSentences.put("C4CE6358DF86040CAAEEBC58951B8E133105D3369980D62D109E5B6B75CCE67C_713x0",
                 "c fjögur c e sex þúsund þrjú hundruð fimmtíu og átta d f átta sex núll fjórir núll c a a e e b c fimm átta níu fimm einn b átta e einn þrír þrír einn núll fimm d þrír þrír sex níu níu átta núll d sextíu og tvö d hundrað og níu e fimm b sex b sjötíu og fimm c c e sextíu og sjö c sjö hundruð og þrettán x núll ."
         );
+        testSentences.put("Mörk Ómars á EM:", "mörk ómars á em .");
+        testSentences.put("til áramóta 2021/2022", "til áramóta tvö þúsund tuttugu og eitt <sil> tvö þúsund tuttugu og tvö .");
+        testSentences.put("© grammatek", "höfundarréttur grammatek .");
 
         return testSentences;
     }

--- a/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
+++ b/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
@@ -28,11 +28,11 @@ public class NormalizationManagerTest {
 
     @Test
     public void processTest() {
-        String input = "til áramóta 2021/2022";
+        String input = "Álfur P er bestur";
         NormalizationManager manager = new NormalizationManager(context);
         String processed = manager.process(input);
         System.out.println(processed);
-        assertEquals("til áramóta tvö þúsund tuttugu og eitt <sil> tvö þúsund tuttugu og tvö .",
+        assertEquals("álfur p er bestur .",
                 processed);
     }
 
@@ -163,6 +163,8 @@ public class NormalizationManagerTest {
         testSentences.put("Mörk Ómars á EM:", "mörk ómars á em .");
         testSentences.put("til áramóta 2021/2022", "til áramóta tvö þúsund tuttugu og eitt <sil> tvö þúsund tuttugu og tvö .");
         testSentences.put("© grammatek", "höfundarréttur grammatek .");
+        testSentences.put("Álfur P er bestur", "álfur p er bestur .");
+        testSentences.put("Það bíður pk eftir þér", "það bíður pakki eftir þér .");
 
         return testSentences;
     }

--- a/app/src/test/java/com/grammatek/simaromur/TTSUnicodeNormalizerTest.java
+++ b/app/src/test/java/com/grammatek/simaromur/TTSUnicodeNormalizerTest.java
@@ -56,5 +56,6 @@ public class TTSUnicodeNormalizerTest {
         sent.put("þessi setning er í tämu tjåni", "þessi setning er í temu tjoni");
         return sent;
     }
+
 }
 


### PR DESCRIPTION
Issues fixed:
- pattern "2021/2022" now resolved, added a corresponding handling in TTSNormalizer.normalizeNumbers. Before, the resolving of this pattern was limited to two digits on each site of the '/'
- token `<sil>` is now preserved, and replaced with lvl-pause symbol in the g2p process
- Normalization for Copyright sign and Registered trademark symbol added
- replacement of [:!?] with '.'
- lexicon updated with the newest version of the dictionary (including single letters)