### PR TITLE
WIP: make speaking stoppable more quickly

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/Utterance.java
+++ b/app/src/main/java/com/grammatek/simaromur/Utterance.java
@@ -1,0 +1,22 @@
+package com.grammatek.simaromur;
+
+import static java.util.UUID.randomUUID;
+
+/**
+ * Utterance class to combine all attributes of a SpeakRequest and make each utterance also uniquely
+ * identifiable.
+ */
+public class Utterance {
+    public String utterance;        //< the raw utterance
+    public String normalized = "";  //< normalized
+    public String g2p = "";         //< after g2p
+    public boolean isActive = false;
+
+    public java.util.UUID id = randomUUID();    //< unique id for identification
+    public float speed = 1.0f;
+    public float pitch = 1.0f;
+
+    public Utterance(String anUtteranceString) {
+        utterance = anUtteranceString;
+    }
+}

--- a/app/src/main/java/com/grammatek/simaromur/VoiceViewModel.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceViewModel.java
@@ -19,9 +19,7 @@ import java.util.Objects;
  */
 public class VoiceViewModel extends AndroidViewModel {
     private final static String LOG_TAG = "Simaromur_" + VoiceViewModel.class.getSimpleName();
-
     private final AppRepository mRepository;
-    private TTSEngineController.SpeakTask mDevSpeakTask = null;
 
     // these variables are for data caching
     private AppData mAppData;                       // application data
@@ -77,7 +75,7 @@ public class VoiceViewModel extends AndroidViewModel {
                 break;
             case Voice.TYPE_TORCH:
             case Voice.TYPE_FLITE:  // FALLTHROUGH
-                mDevSpeakTask = mRepository.startDeviceSpeak(voice, text, speed, pitch, finishedObserver);
+                mRepository.startDeviceSpeak(voice, text, speed, pitch, finishedObserver);
                 break;
             default:
                 // other voice types follow here ..
@@ -92,10 +90,9 @@ public class VoiceViewModel extends AndroidViewModel {
         if (voice.type.equals(Voice.TYPE_TIRO)) {
             mRepository.stopTiroSpeak();
         } else if (voice.type.equals(Voice.TYPE_TORCH)) {
-            mRepository.stopDeviceSpeak(mDevSpeakTask);
+            mRepository.stopDeviceSpeak();
         } else {
             // other voice types follow here ..
         }
-        mDevSpeakTask = null;
     }
 }

--- a/app/src/main/java/com/grammatek/simaromur/device/TTSEngine.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/TTSEngine.java
@@ -22,4 +22,9 @@ public interface TTSEngine {
      * @return  Native sample rate of voice.
      */
     int GetNativeSampleRate();
+
+    /**
+     * Stops any ongoing synthesis
+     */
+    void Stop();
 }

--- a/app/src/main/java/com/grammatek/simaromur/device/TTSEngineFlite.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/TTSEngineFlite.java
@@ -65,4 +65,9 @@ public class TTSEngineFlite  implements TTSEngine {
     public int GetNativeSampleRate() {
         return 22050;
     }
+
+    @Override
+    public void Stop() {
+
+    }
 }

--- a/app/src/main/java/com/grammatek/simaromur/device/TTSEngineTensorFlow.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/TTSEngineTensorFlow.java
@@ -39,4 +39,9 @@ public class TTSEngineTensorFlow implements TTSEngine {
     public int GetNativeSampleRate() {
         return SAMPLE_RATE;
     }
+
+    @Override
+    public void Stop() {
+
+    }
 }


### PR DESCRIPTION
This merge request is just a place-holder for further work. This is a first draft to work on multiple ideas, but we are not there yet.

First approach to make speaking stoppable more quickly, but dead-locks sometimes.

Should be split probably into multiple independen pieces.

- `class TTSEnginePyTorch`: make the pipeline stoppable: ask after each pipeline step, if the request has already been stopped and break early
- `class TTSEngineController`: split long utterances at symbol @sp, to parallelize on-device audio generation and playing audio. This can help to bring  down latency
- Introduce clas Utterance to combine all attributes for a speak request and save intermediate pipeline results. This is not put into action yet, but should be created in `TTSService::onSynthesizeText()`
- `class AppRepository`: move `SpeakTask` here and add method `stopSpeaking()`. Here probably the deadlock happens.
