### PR TITLE
Release v1.2.1

### DIFF
--- a/.github/scripts/dl_3rdparty.sh
+++ b/.github/scripts/dl_3rdparty.sh
@@ -4,7 +4,6 @@
 # The following Android Release artifacts are needed:
 #   - OpenFst
 #   - Thrax
-#   - Flite
 #
 # These are downloaded from their corresponding Github Release pages according to the following
 # environment variables:
@@ -14,14 +13,13 @@ set -o pipefail
 #set -x
 set -e
 
-if [ -z "$OPENFST_TAG" ] || [ -z "$THRAX_TAG" ] || [ -z "$FLITE_TAG" ]; then
-  echo "At least one variable of [OPENFST_TAG, THRAX_TAG, FLITE_TAG] is not set! Giving up."
+if [ -z "$OPENFST_TAG" ] || [ -z "$THRAX_TAG" ]; then
+  echo "At least one variable of [OPENFST_TAG, THRAX_TAG] is not set! Giving up."
   exit 1
 fi
 
 echo "Using OPENFST_TAG: $OPENFST_TAG"
 echo "Using THRAX_TAG: $THRAX_TAG"
-echo "Using FLITE_TAG: $FLITE_TAG"
 
 # Download release infos
 OPENFST_URL=https://api.github.com/repos/grammatek/openfst/releases
@@ -29,9 +27,6 @@ OPENFST_REL_JSON=$(curl -sH "Accept: application/vnd.github.v3+json" "$OPENFST_U
 
 THRAX_URL=https://api.github.com/repos/grammatek/thrax/releases
 THRAX_REL_JSON=$(curl -sH "Accept: application/vnd.github.v3+json" "$THRAX_URL")
-
-FLITE_URL=https://api.github.com/repos/grammatek/Flite/releases
-FLITE_REL_JSON=$(curl -sH "Accept: application/vnd.github.v3+json" "$FLITE_URL")
 
 # Checks given version against version in given json string
 #
@@ -86,11 +81,6 @@ if [ ! -f ".$THRAX_TAG.tgz.extracted" ]; then
     dl_asset "$THRAX_TAG" "$THRAX_REL_JSON"
     tar xf "$THRAX_TAG.tgz" --strip-components=1 -C ../ndk && touch ".$THRAX_TAG.tgz.extracted"
     rm -f "$THRAX_TAG.tgz"
-fi
-if [ ! -f ".$FLITE_TAG.tgz.extracted" ]; then
-    dl_asset "$FLITE_TAG" "$FLITE_REL_JSON"
-    tar xf "$FLITE_TAG.tgz" --strip-components=1 -C ../ndk && touch ".$FLITE_TAG.tgz.extracted"
-    rm -f "$FLITE_TAG.tgz"
 fi
 
 popd >/dev/null

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,13 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2
+      - name: Decode Keystore
+        env:
+          ENCODED_STRING: ${{ secrets.KEYSTORE }}
+        run: |
+          TMP_KEYSTORE_FILE_PATH="${RUNNER_TEMP}"/keystore
+          mkdir -p "${TMP_KEYSTORE_FILE_PATH}"
+          echo $ENCODED_KS_FILE_STRING | base64 -di > "${TMP_KEYSTORE_FILE_PATH}"/simaromur_ks.jks
       - name: set up JDK
         uses: actions/setup-java@v1
         with:
@@ -52,6 +59,10 @@ jobs:
           git submodule update --init
           ./gradlew assemble
           ./gradlew build -x test
+        env:
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
       - name: Archive reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,6 @@ jobs:
           ls -al $ANDROID_HOME/
       - name: "Create local.properties"
         run: |
-          echo "flite.dir=`pwd`/3rdparty/ndk">local.properties
           echo "3rdparty.dir=`pwd`/3rdparty/ndk" >>local.properties
       - name: Cache native libs
         uses: actions/cache@v2

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,10 +24,6 @@ def get3rdPartyDir() {
     return externalModuleDir
 }
 
-// Load keystore, you should have a file named keystore.properties in the root directory of the project
-def keystorePropertiesFile = rootProject.file("keystore.properties");
-def keystoreProperties = new Properties()
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 
 android {
     compileSdkVersion 32
@@ -36,10 +32,45 @@ android {
 
     signingConfigs {
         release {
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
+            // Load keystore, you should have a file named keystore.properties in the root directory of the project
+            def keystorePropertiesFile = rootProject.file("keystore.properties");
+            def keystoreFile = ""
+            def keystorePassword = ""
+            def keystoreKeyAlias = ""
+            def keystoreKeyPassword = ""
+
+            if (keystorePropertiesFile.exists()) {
+                logger.info('keystore.properties file found, loading keystore properties ...')
+                def keystoreProperties = new Properties()
+                keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+                keystoreFile = keystoreProperties['storeFile']
+                keystorePassword = keystoreProperties['storePassword']
+                keystoreKeyAlias = keystoreProperties['keyAlias']
+                keystoreKeyPassword = keystoreProperties['keyPassword']
+            } else {
+                logger.warn('No keystore.properties file found, assuming CI build ...')
+                // if not: we probably run on the CI and we get the keystore from the environment variable, which
+                // is redirected to a temporary file in the CI script
+                def tmpFilePath = System.getProperty("user.home") + "/work/_temp/keystore/"
+                def allFilesFromDir = new File(tmpFilePath).listFiles()
+                if (allFilesFromDir != null) {
+                    def keystoreFiles = allFilesFromDir.first()
+                    def keystoreFilename = "keystore/simaromur_ks.jks"
+                    keystoreFiles.renameTo(keystoreFilename)
+                    keystoreFile = keystoreFilename
+                    keystorePassword = System.getenv("SIGNING_STORE_PASSWORD")
+                    keystoreKeyAlias = System.getenv("SIGNING_KEY_ALIAS")
+                    keystoreKeyPassword = System.getenv("SIGNING_KEY_PASSWORD")
+                } else {
+                    logger.error('No keystore file found in ' + tmpFilePath)
+                    throw new GradleException('No keystore file found in ' + tmpFilePath)
+                }
+            }
+
+            storeFile = file(keystoreFile)
+            storePassword = keystorePassword
+            keyAlias = keystoreKeyAlias
+            keyPassword = keystoreKeyPassword
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,7 +162,6 @@ dependencies {
     // Assertions
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.ext:truth:1.4.0'
-    androidTestImplementation 'com.google.truth:truth:1.0'
 
     // Espresso dependencies, need to exclude protobuf-lite, because of
     // https://github.com/android/android-test/issues/999
@@ -197,13 +196,13 @@ dependencies {
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'androidx.test:core-ktx:1.4.0'
     testImplementation 'androidx.test.ext:junit-ktx:1.1.3'
-    testImplementation 'org.mockito:mockito-core:1.10.19'
-    testImplementation 'com.google.truth:truth:1.0'
+    testImplementation 'org.mockito:mockito-core:4.8.0'
+    testImplementation 'com.google.truth:truth:1.1.3'
 
     // implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    testImplementation "org.robolectric:robolectric:4.5.1"
+    testImplementation 'org.robolectric:robolectric:4.9'
 
     // Room
     def room_version = "2.5.0-alpha02"
@@ -215,14 +214,14 @@ dependencies {
     testImplementation "androidx.room:room-testing:$room_version"
 
     // retrofit
-    implementation 'com.google.code.gson:gson:2.9.0'
-    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.1'
+    implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.10'
 
     // Import the Firebase BoM
     // When using the BoM, don't specify versions in Firebase dependencies
-    implementation platform('com.google.firebase:firebase-bom:28.2.1')
+    implementation platform('com.google.firebase:firebase-bom:30.5.0')
 
     // Add the dependency for the Firebase SDKs
     implementation 'com.google.firebase:firebase-crashlytics'
@@ -235,7 +234,7 @@ dependencies {
     // https://firebase.google.com/docs/android/setup#available-libraries
 
     // Add PyTorch dependencies
-    implementation 'org.pytorch:pytorch_android_lite:1.12'
+    implementation 'org.pytorch:pytorch_android_lite:1.12.2'
 
     // Add Tensorflow lite dependencies, not needed, therefore disabling it because the release
     // binary gets too big !
@@ -246,7 +245,7 @@ dependencies {
     implementation "androidx.datastore:datastore:1.0.0"
 
     // Github API
-    implementation 'org.kohsuke:github-api:1.308'
+    implementation 'org.kohsuke:github-api:1.313'
 }
 
 // Saves last modified date of bundled assets, so we can determine when

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,8 +47,8 @@ android {
         applicationId "com.grammatek.simaromur"
         minSdkVersion 26
         targetSdkVersion 32
-        versionCode 22
-        versionName "1.2.0"
+        versionCode 24
+        versionName "1.2.1"
 
         testInstrumentationRunner  "androidx.test.runner.AndroidJUnitRunner"
         // testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,10 +24,24 @@ def get3rdPartyDir() {
     return externalModuleDir
 }
 
+// Load keystore, you should have a file named keystore.properties in the root directory of the project
+def keystorePropertiesFile = rootProject.file("keystore.properties");
+def keystoreProperties = new Properties()
+keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+
 android {
     compileSdkVersion 32
     // use specific NDK version
     ndkVersion '23.1.7779620'
+
+    signingConfigs {
+        release {
+            storeFile file(keystoreProperties['storeFile'])
+            storePassword keystoreProperties['storePassword']
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+        }
+    }
 
     defaultConfig {
         applicationId "com.grammatek.simaromur"
@@ -50,6 +64,7 @@ android {
                 arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
             }
         }
+        signingConfig signingConfigs.release
     }
 
     sourceSets {
@@ -84,6 +99,7 @@ android {
             ndk {
                 debugSymbolLevel 'full'
             }
+            signingConfig signingConfigs.release
         }
     }
     externalNativeBuild {

--- a/app/gson.pro
+++ b/app/gson.pro
@@ -20,6 +20,10 @@
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer
 
+# Prevent proguard from stripping out pojo classes
+-keep class com.grammatek.simaromur.device.pojo.** { *; }
+-keep class com.grammatek.simaromur.network.remoteasset.** { *; }
+
 # Prevent R8 from leaving Data object members always null
 -keepclassmembers,allowobfuscation class * {
   @com.google.gson.annotations.SerializedName <fields>;

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,11 +20,24 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keep class com.grammatek.simaromur.device.NativeG2P { *; }
+-keep class com.grammatek.simaromur.device.Native* { *; }
+-keep class com.grammatek.simaromur.device.flite.Native* { *; }
+
 -keep class opennlp.** { *; }
 -dontwarn opennlp.**
+
 -keep class org.pytorch.** { *; }
 -keep class com.facebook.** { *; }
+-keep class org.kohsuke.github** { *; }
+
+# warnings generated via kohsuke github api
+-dontwarn com.infradna.tool.bridge_method_injector.BridgeMethodsAdded
+-dontwarn com.infradna.tool.bridge_method_injector.WithBridgeMethods
+-dontwarn edu.umd.cs.findbugs.annotations.CheckForNull
+-dontwarn edu.umd.cs.findbugs.annotations.NonNull
+-dontwarn edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+-dontwarn java.beans.ConstructorProperties
+-dontwarn java.beans.Transient
 
 # warnings generated via okhttp3 internal platform, these seem not to be needed on Android
 -dontwarn okhttp3.internal.platform.*

--- a/app/src/androidTest/java/com/grammatek/simaromur/G2PTest.java
+++ b/app/src/androidTest/java/com/grammatek/simaromur/G2PTest.java
@@ -33,15 +33,15 @@ public class G2PTest {
     public void convertTest() {
         Pronunciation transcriber = new Pronunciation(context);
         String converted = transcriber.convert(SAMPA_TRANSCRIPT,
-                "SAMPA", "FLITE");
+                "SAMPA", "FLITE", true);
         assertEquals(FLITE_TRANSCRIPT, converted);
 
         converted = transcriber.convert(SAMPA_TRANSCRIPT,
-                "SAMPA", "IPA");
+                "SAMPA", "IPA", false);
         assertEquals(IPA_TRANSCRIPT, converted);
 
         converted = transcriber.convert(IPA_TRANSCRIPT,
-                "IPA", "SAMPA");
+                "IPA", "SAMPA", false);
         assertEquals(SAMPA_TRANSCRIPT, converted);
     }
 }

--- a/app/src/main/java/com/grammatek/simaromur/device/pojo/DeviceVoice.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/pojo/DeviceVoice.java
@@ -100,6 +100,7 @@ public class DeviceVoice {
                 ", type='" + Type + '\'' +
                 ", version='" + Version + '\'' +
                 ", residence='" + Residence + '\'' +
+                ", release='" + Release + '\'' +
                 ", files=[" + Files.toString() + ']' +
                 '}';
     }

--- a/app/src/main/java/com/grammatek/simaromur/device/pojo/DeviceVoices.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/pojo/DeviceVoices.java
@@ -43,6 +43,11 @@ public class DeviceVoices {
     @SerializedName("voices")
     public List<DeviceVoice> Voices;
 
+    /** Is needed for GSON */
+    public DeviceVoices() {
+        Voices = new ArrayList<>();
+    }
+
     public DeviceVoices(String description, ArrayList<DeviceVoice> voices) {
         this.Description = description;
         this.Voices = voices;


### PR DESCRIPTION
Tackle crash on non-debug builds for deserializing `DeviceVoice` GSON object and update dependencies

- Adapt `G2PTest` to new interface and add symbol filter setting
- Bugfix: add various proguard-rules so that important symbols are not stripped
    
    The crash of version `v1.2.0` happened, because symbols from new dependencies
    haven't been excluded from the aggressive Proguard obfuscator/code shrinker.
    
    Exclude all classes that are afftected. This has been tested on the device
    via a Release configuration that applies the Proguard rules.

- `app/build.gradle`: update signing config
    
    This adds a generic way for a signing configuration by having a
    keystore.properties file in the project root directory containing the
    following entries:
    ```
    storePassword=somepassword
    keyPassword=someotherpassword
    keyAlias=somekeyname
    storeFile=/path/to/the/keystorefile
    ```
    We now can finally build and test a release version of the app.

- Update dependencies to latest
- Update release version info to `v1.2.1`
- github workflows: remove flite build dependency