### PR TITLE
updating download voice dialog

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/VoiceInfo.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceInfo.java
@@ -1,7 +1,7 @@
 package com.grammatek.simaromur;
 
 import android.annotation.SuppressLint;
-import android.app.ProgressDialog;
+import android.app.AlertDialog;
 import android.content.pm.ActivityInfo;
 import android.graphics.Color;
 import android.os.Bundle;
@@ -36,7 +36,8 @@ public class VoiceInfo extends AppCompatActivity {
     private com.grammatek.simaromur.db.Voice mVoice;
     private VoiceViewModel mVoiceViewModel;
     private ImageView mNetworkAvailabilityIcon;
-    private ProgressDialog mProgressDialog;
+    private ProgressBar mProgressBar;
+    private TextView mProgressBarPercentage;
 
     @SuppressLint("SourceLockedOrientationActivity")
     @Override
@@ -44,6 +45,8 @@ public class VoiceInfo extends AppCompatActivity {
         Log.v(LOG_TAG, "onCreate");
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_voice_info);
+        mProgressBar = findViewById(R.id.progressBar);
+        mProgressBarPercentage = findViewById(R.id.pbPercentage);
 
         final Bundle extras = getIntent().getExtras();
         if (extras != null) {
@@ -207,33 +210,48 @@ public class VoiceInfo extends AppCompatActivity {
         }
     }
 
-    /**
-     * Toggles the "Download button to show a horizontal progress bar and back again in case
-     * download is finished.
-     */
     class DownloadObserver implements DownloadVoiceManager.DownloadObserver {
-        ProgressDialog mProgressDialog;
-        DownloadObserver(ProgressDialog dialog) {
-            mProgressDialog = dialog;
+        ProgressBar mProgressBar;
+        DownloadObserver(ProgressBar progressBar) {
+            mProgressBar = progressBar;
         }
 
         @Override
         public void hasFinished(boolean success) {
             runOnUiThread(VoiceInfo.this::toggleDownloadButton);
-            mProgressDialog.dismiss();
+            toggleDownloadButton();
+
+            // hide from the UI whether the download is a success or not.
+            findViewById(R.id.ccProgressBar).setVisibility(View.GONE);
+            if (!success) {
+                findViewById(R.id.llProgressBar).setVisibility(View.GONE);
+                AlertDialog.Builder b = new AlertDialog.Builder(VoiceInfo.this);
+                b.setMessage(R.string.download_failed);
+                b.setCancelable(true);
+                b.create().show();
+            }
         }
         @Override
         public void updateProgress(int progress) {
-            runOnUiThread(() -> {
-                mProgressDialog.setProgress(progress);
-            });
+                runOnUiThread(() -> {
+                    mProgressBar.setProgress(progress);
+                    String progress_in_percentage = progress + "%";
+                    mProgressBarPercentage.setText(progress_in_percentage);
+                });
+                if (progress == 100) {
+                    Log.d(LOG_TAG, "Finished downloading file.. unzipping..");
+                    runOnUiThread(() -> {
+                        // swap view to indeterminate progress bar to allow the voice to unzip peacefully
+                        findViewById(R.id.llProgressBar).setVisibility(View.GONE);
+                        findViewById(R.id.ccProgressBar).setVisibility(View.VISIBLE);
+                    });
+            }
         }
         @Override
         public void hasError(String error) {
             runOnUiThread(() -> {
                 Toast.makeText(VoiceInfo.this, error, Toast.LENGTH_LONG).show();
                 toggleDownloadButton();
-                mProgressDialog.dismiss();
             });
         }
     }
@@ -295,20 +313,17 @@ public class VoiceInfo extends AppCompatActivity {
     public void onDownloadClicked(View v) {
         Log.v(LOG_TAG, "onDownloadClicked");
         toggleDownloadButton();
-        // TODO: deprecated API ...
-        mProgressDialog = new ProgressDialog(this);
-        mProgressDialog.setMax(100);
-        mProgressDialog.setMessage(getResources().getString(R.string.do_download));
-        mProgressDialog.setTitle(mVoice.name);
-        mProgressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
-        mProgressDialog.show();
-        mProgressDialog.setCancelable(true);
-        mProgressDialog.setOnCancelListener(dialog -> {
+
+        findViewById(R.id.llProgressBar).setVisibility(View.VISIBLE);
+        mProgressBar.setVisibility(View.VISIBLE);
+        Button cancelButton = findViewById(R.id.cancel_button);
+        cancelButton.setOnClickListener(view -> {
             Log.v(LOG_TAG, "onDownloadClicked: download cancelled");
             App.getAppRepository().cancelDownloadVoice();
             toggleDownloadButton();
+            findViewById(R.id.llProgressBar).setVisibility(View.GONE);
         });
-        App.getAppRepository().downloadVoiceAsync(mVoice, new DownloadObserver(mProgressDialog));
+        App.getAppRepository().downloadVoiceAsync(mVoice, new DownloadObserver(mProgressBar));
     }
 
     /**
@@ -332,6 +347,7 @@ public class VoiceInfo extends AppCompatActivity {
      * play button back again otherwise.
      */
     private void toggleDownloadButton() {
+        Log.d(LOG_TAG, "toggling");
         Button button = findViewById(R.id.download_button);
         if (button.getVisibility() == View.VISIBLE) {
             button.setVisibility(View.INVISIBLE);
@@ -342,6 +358,8 @@ public class VoiceInfo extends AppCompatActivity {
                 button.setVisibility(View.VISIBLE);
                 button.setText(R.string.speak_voice_title);
                 mUserText.setVisibility(View.VISIBLE);
+            } else {
+                button.setVisibility(View.VISIBLE);
             }
         }
     }

--- a/app/src/main/java/com/grammatek/simaromur/VoiceInfo.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceInfo.java
@@ -24,6 +24,7 @@ import com.grammatek.simaromur.network.ConnectionCheck;
 
 import static com.grammatek.simaromur.VoiceManager.EXTRA_DATA_VOICE_ID;
 
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -184,6 +185,7 @@ public class VoiceInfo extends AppCompatActivity {
         Log.v(LOG_TAG, "onDestroy:");
         super.onDestroy();
         mVoiceViewModel.stopSpeaking(mVoice);
+        App.getAppRepository().cancelDownloadVoice();
     }
 
     @Override
@@ -215,6 +217,8 @@ public class VoiceInfo extends AppCompatActivity {
         ProgressBar mProgressBar;
         DownloadObserver(ProgressBar progressBar) {
             mProgressBar = progressBar;
+            mProgressBar.setProgress(0);
+            mProgressBarPercentage.setText("0%");
         }
 
         @Override
@@ -247,7 +251,7 @@ public class VoiceInfo extends AppCompatActivity {
         @Override
         public void hasError(String error) {
             // Tell user something went wrong unless it's from him cancelling the download.
-            if (!Objects.equals(error, "stream was reset: CANCEL (-1)")) {
+            if (!error.matches("(?i).*cancel.*")) {
                 runOnUiThread(() -> {
                     findViewById(R.id.llProgressBar).setVisibility(View.GONE);
                     AlertDialog.Builder b = new AlertDialog.Builder(VoiceInfo.this);

--- a/app/src/main/java/com/grammatek/simaromur/device/DownloadVoiceManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/DownloadVoiceManager.java
@@ -383,6 +383,7 @@ public class DownloadVoiceManager {
                             App.getContext().getFilesDir().getPath() + "/voices", ignoreList);
 
                     if (!decompress.unzip()) {
+                        // TODO: please try again
                         Log.e(LOG_TAG, "Could not unzip voice file " + fileName);
                         FileUtils.delete(fileName);
                     } else {
@@ -471,13 +472,13 @@ public class DownloadVoiceManager {
 
             @Override
             public void onPostExecute() {
-                // reset spinner
-                aDownloadObserver.hasFinished(isDownloadOk());
                 if (!voiceRepoOk) {
                     Log.w(LOG_TAG, "Voice repository not available, probable rate limit exceeded");
                     Log.w(LOG_TAG, "Try again later");
                     // showTryAgainDialog();
                 }
+                // reset spinner
+                aDownloadObserver.hasFinished(isDownloadOk());
             }
         };
         mAsyncThread.execute("DownloadVoiceThread");

--- a/app/src/main/java/com/grammatek/simaromur/network/remoteasset/VoiceRepo.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/remoteasset/VoiceRepo.java
@@ -8,6 +8,7 @@ import com.google.gson.Gson;
 import com.grammatek.simaromur.App;
 
 import org.kohsuke.github.GHAsset;
+import org.kohsuke.github.GHException;
 import org.kohsuke.github.GHRateLimit;
 import org.kohsuke.github.GHRelease;
 import org.kohsuke.github.GHRepository;
@@ -277,7 +278,7 @@ public class VoiceRepo {
                     }
                 }
             }
-        } catch (IOException e) {
+        } catch (IOException | GHException e) {
             e.printStackTrace();
         }
         return null;

--- a/app/src/main/java/com/grammatek/simaromur/utils/AsyncThread.java
+++ b/app/src/main/java/com/grammatek/simaromur/utils/AsyncThread.java
@@ -6,6 +6,7 @@ import android.util.Log;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class provides a simple way to run a task in a background thread and
@@ -54,6 +55,16 @@ public abstract class AsyncThread {
 
     public void shutdown() {
         executors.shutdown();
+        boolean terminated = false;
+        try {
+            // try to gracefully shutdown the executor
+            terminated = executors.awaitTermination(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        if (!terminated) {
+            executors.shutdownNow();
+        }
     }
 
     public boolean isShutdown() {

--- a/app/src/main/java/com/grammatek/simaromur/utils/Decompress.java
+++ b/app/src/main/java/com/grammatek/simaromur/utils/Decompress.java
@@ -73,11 +73,45 @@ public class Decompress {
             zipInputStream.close();
             return true;
         } catch(Exception e) {
-            Log.e("Decompress", "unzip", e);
+            Log.e(LOG_TAG, "unzip: ", e);
         }
         return false;
     }
 
+    /**
+     * Gets the paths of all files in the ZIP archive when decompressed at their
+     * final destination.
+     *
+     * @return  List of paths
+     */
+    public ArrayList<String> getDestinationPathEntries() {
+        ArrayList<String> entries = new ArrayList<>();
+        try  {
+            FileInputStream inputStream = new FileInputStream(mZipfile);
+            ZipInputStream zipInputStream = new ZipInputStream(inputStream);
+            ZipEntry zipEntry;
+            while ((zipEntry = zipInputStream.getNextEntry()) != null) {
+                Log.v(LOG_TAG, "found " + zipEntry.getName());
+                if (zipEntry.isDirectory() || matchIgnoreList(zipEntry)) {
+                    Log.v(LOG_TAG, "Ignoring " + zipEntry.getName());
+                } else {
+                    entries.add(mLocation + zipEntry.getName());
+                    zipInputStream.closeEntry();
+                }
+            }
+            zipInputStream.close();
+        } catch(Exception e) {
+            Log.e(LOG_TAG, "getEntries: ", e);
+        }
+        return entries;
+    }
+
+    /**
+     * Returns boolean if the given zipEntry matches any of the entries in the ignore list.
+     *
+     * @param zipEntry  ZipEntry to be checked
+     * @return  true if the entry matches, false otherwise
+     */
     private boolean matchIgnoreList(ZipEntry zipEntry) {
         for (String ignoredFile : mIgnoredFiles) {
             if (zipEntry.getName().endsWith(ignoredFile)) {

--- a/app/src/main/res/layout/activity_progress_bar.xml
+++ b/app/src/main/res/layout/activity_progress_bar.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:gravity="center"
     android:orientation="vertical"
-    android:background="#E6FFFFFF"
+    android:background="@color/colorPrimaryDark"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -15,7 +15,7 @@
         android:layout_marginBottom="8dp"
         android:gravity="center_horizontal"
         android:text="@string/downloading_voice"
-        android:textColor="@color/colorPrimary"
+        android:textColor="@color/white"
         android:textStyle="bold" />
 
     <ProgressBar
@@ -25,9 +25,9 @@
         android:minWidth="260dp"
         android:minHeight="50dp"
         android:max="100"
-        android:progress="0"
-        style="?android:attr/progressBarStyleHorizontal"
-        />
+        android:progress="50"
+        android:progressBackgroundTint="@color/white"
+        style="?android:attr/progressBarStyleHorizontal" />
 
     <TextView
         android:id="@+id/pbPercentage"
@@ -36,7 +36,7 @@
         android:layout_marginTop="0dp"
         android:gravity="center"
         android:text="@string/downloading_progress"
-        android:textColor="@color/colorPrimary"
+        android:textColor="@color/white"
         android:textStyle="bold" />
 
     <Button

--- a/app/src/main/res/layout/activity_progress_bar.xml
+++ b/app/src/main/res/layout/activity_progress_bar.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:background="#E6FFFFFF"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/pbText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:gravity="center_horizontal"
+        android:text="@string/downloading_voice"
+        android:textColor="@color/colorPrimary"
+        android:textStyle="bold" />
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="260dp"
+        android:minHeight="50dp"
+        android:max="100"
+        android:progress="0"
+        style="?android:attr/progressBarStyleHorizontal"
+        />
+
+    <TextView
+        android:id="@+id/pbPercentage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="0dp"
+        android:gravity="center"
+        android:text="@string/downloading_progress"
+        android:textColor="@color/colorPrimary"
+        android:textStyle="bold" />
+
+    <Button
+        android:id="@+id/cancel_button"
+        style="@style/cancel_download_style"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/cancel"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_progress_bar_indeterminate.xml
+++ b/app/src/main/res/layout/activity_progress_bar_indeterminate.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:gravity="center"
     android:orientation="vertical"
-    android:background="#CCFFFFFF"
+    android:background="@color/colorPrimaryDark"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -15,7 +15,7 @@
         android:layout_marginBottom="8dp"
         android:gravity="center_horizontal"
         android:text="@string/unzipping_voice"
-        android:textColor="@color/colorPrimary"
+        android:textColor="@color/white"
         android:textStyle="bold" />
 
     <ProgressBar

--- a/app/src/main/res/layout/activity_progress_bar_indeterminate.xml
+++ b/app/src/main/res/layout/activity_progress_bar_indeterminate.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:background="#CCFFFFFF"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/pbText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:gravity="center_horizontal"
+        android:text="@string/unzipping_voice"
+        android:textColor="@color/colorPrimary"
+        android:textStyle="bold" />
+
+    <ProgressBar
+        android:id="@+id/progressBarCircle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="260dp"
+        android:minHeight="50dp"
+        />
+
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_voice_info.xml
+++ b/app/src/main/res/layout/activity_voice_info.xml
@@ -188,4 +188,14 @@
         app:layout_constraintStart_toStartOf="@+id/speakable_text"
         app:layout_constraintTop_toTopOf="@+id/speakable_text" />
 
+    <include
+        android:id="@+id/llProgressBar"
+        android:visibility="gone"
+        layout="@layout/activity_progress_bar" />
+
+    <include
+        android:id="@+id/ccProgressBar"
+        android:visibility="gone"
+        layout="@layout/activity_progress_bar_indeterminate" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-is-rIS/strings.xml
+++ b/app/src/main/res/values-is-rIS/strings.xml
@@ -73,4 +73,8 @@
     <string name="cache_cleared">Skyndiminni hreinsað</string>
     <string name="megabyte"> MB</string>
     <string name="percentage">%</string>
+    <string name="downloading_voice">Sæki rödd…</string>
+    <string name="downloading_progress">0%</string>
+    <string name="unzipping_voice">Uppsetning á rödd…</string>
+    <string name="download_failed">Það fór eitthvað úrskeiðis, vinsamlegast reyndu aftur.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="simaromur_feedback">Feedback</string>
     <string name="email_subject">Feedback on Símarómur</string>
     <string name="email_message">Feedback: </string>
-    <string name= "send_message">Send mail …</string>
+    <string name="send_message">Send mail …</string>
     <string name="tts_settings_label">TTS Settings</string>
     <string name="voice_list_update">Download Voice List</string>
     <string name="speak_button">Play</string>
@@ -73,4 +73,8 @@
     <string name="cache_progress_percent">%1$d%%</string>
     <string name="megabyte"> MB</string>
     <string name="percentage">%</string>
+    <string name="downloading_voice">Downloading voice…</string>
+    <string name="downloading_progress">0%</string>
+    <string name="unzipping_voice">Setting up voice…</string>
+    <string name="download_failed">Something went wrong, please try again.</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -94,4 +94,17 @@
         <item name="android:textColor">@color/colorTextPrimary</item>
     </style>
 
+    <style name="cancel_download_style" parent="android:style/Widget.Material.Button">
+        <!-- Customize your theme here. -->
+        <item name="android:buttonStyle">@style/Widget.MaterialComponents.Button.OutlinedButton</item>
+        <item name="android:theme">@style/Theme.MaterialComponents</item>
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:background">@drawable/transparent_bg_bordered_button</item>
+        <item name="android:backgroundTint">@color/colorPrimaryDark</item>
+        <item name="android:textAppearance">@android:style/TextAppearance.Large</item>
+        <item name="android:layout_marginTop">16dp</item>
+        <item name="android:textColor">@color/colorPrimaryDark</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -101,10 +101,10 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:background">@drawable/transparent_bg_bordered_button</item>
-        <item name="android:backgroundTint">@color/colorPrimaryDark</item>
+        <item name="android:backgroundTint">@color/white</item>
         <item name="android:textAppearance">@android:style/TextAppearance.Large</item>
         <item name="android:layout_marginTop">16dp</item>
-        <item name="android:textColor">@color/colorPrimaryDark</item>
+        <item name="android:textColor">@color/white</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Updating the deprecated `ProgressDialog` to `AlertDialog` with a `determinate` progress bar (0% - 100%) for downloading a voice, once the voice is downloaded the progress bar turns into an `indeterminate` progress bar (cyclical animation) so the voice can be safely unzipped.

Adding more error handling to increase robustness and adding an `AlertDialog` for when things fail, the user is prompted and suggested to try again. 