### PR TITLE
Make connection to github configurable

### DIFF
--- a/app/src/main/assets/config.properties
+++ b/app/src/main/assets/config.properties
@@ -1,0 +1,5 @@
+# This file can be used to set various properties for the app
+
+# Credentials for github to circumvent the 60 requests per hour limit
+# set a token for your account here to increase the limit to 5000 requests per hour
+github_auth0_token =

--- a/app/src/main/java/com/grammatek/simaromur/AppRepository.java
+++ b/app/src/main/java/com/grammatek/simaromur/AppRepository.java
@@ -38,6 +38,7 @@ import com.grammatek.simaromur.network.tiro.SpeakController;
 import com.grammatek.simaromur.network.tiro.VoiceController;
 import com.grammatek.simaromur.network.tiro.pojo.SpeakRequest;
 import com.grammatek.simaromur.network.tiro.pojo.VoiceResponse;
+import com.grammatek.simaromur.utils.FileUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -88,6 +89,21 @@ public class AppRepository {
 
     // contains the currently handled tts request from onSynthesizeText()
     private TTSRequest mCurrentRequest;
+
+    /**
+     * Returns configuration value for given key in the config.properties file.
+     *
+     * @param key   key to look up
+     * @return    value for key or empty string if not found
+     */
+    public String getAssetConfigValueFor(String key) {
+        try {
+            return FileUtils.getAssetConfigProperty(App.getContext().getAssets(), key);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
 
     /**
      * Download given voice from voice repository asynchronously. After download is finished or

--- a/app/src/main/java/com/grammatek/simaromur/network/remoteasset/VoiceRepo.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/remoteasset/VoiceRepo.java
@@ -1,19 +1,17 @@
 package com.grammatek.simaromur.network.remoteasset;
 
-import android.os.Build;
-import android.os.LimitExceededException;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
 
 import com.google.gson.Gson;
+import com.grammatek.simaromur.App;
 
 import org.kohsuke.github.GHAsset;
 import org.kohsuke.github.GHRateLimit;
 import org.kohsuke.github.GHRelease;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
-import org.kohsuke.github.GitHubRateLimitHandler;
 import org.kohsuke.github.PagedIterable;
 
 import java.io.File;
@@ -61,7 +59,14 @@ public class VoiceRepo {
      */
     public VoiceRepo(String assetRepoUrl) throws IOException, LimitExceededException {
         mAssetRepoUrl = assetRepoUrl;
-        mGithub = GitHub.connectAnonymously();
+        // your personal access token is required to avoid rate limiting (60 requests per hour)
+        final String oAuthToken = App.getAppRepository().getAssetConfigValueFor("github_auth0_token");
+        if (oAuthToken.isEmpty()) {
+            mGithub = GitHub.connectAnonymously();
+        } else {
+            // this sets the rate limit to 5000 requests per hour
+            mGithub = GitHub.connectUsingOAuth(oAuthToken);
+        }
         GHRateLimit rateLimit = mGithub.getRateLimit();
         Log.v(LOG_TAG, "GitHub rate limit: remaining " + rateLimit.getRemaining() + " accesses, reset at " + rateLimit.getResetDate());
         if (rateLimit.getRemaining() == 0) {

--- a/app/src/main/java/com/grammatek/simaromur/utils/FileUtils.java
+++ b/app/src/main/java/com/grammatek/simaromur/utils/FileUtils.java
@@ -30,6 +30,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Properties;
 
 public class FileUtils {
     private final static String LOG_TAG = "Simaromur_" + FileUtils.class.getSimpleName();
@@ -380,5 +381,20 @@ public class FileUtils {
                     + e.getMessage());
         }
         return rv;
+    }
+
+    /**
+     * Reads the config.properties file from the assets directory and returns the contents of the
+     * given key
+     * @param assetManager      AssetManager to be used for operation
+     * @param key               Key to be used for operation
+     * @return            Value of key in config.properties
+     */
+    public static String getAssetConfigProperty(AssetManager assetManager, String key) throws IOException {
+        InputStream inputStream = assetManager.open("config.properties");
+        Properties properties = new Properties();
+        properties.load(inputStream);
+        inputStream.close();
+        return properties.getProperty(key);
     }
 }


### PR DESCRIPTION
This is done via a new file `assets/config.properties`, which should contain e.g. debugging or configuration options that don't change over a restart of the app.

A new property `github_auth0_token` makes it possible to circumvent the 60 requests/hour rate limit for anonymous access to github. Normally this is no problem for normal users, as the voice release info is cached to local memory and only queried once an hour, but for debugging purposes this is too strict.

- add `FileUtils#getAssetConfigProperty()`
- add `AppRepository#getAssetConfigValueFor()`
- add querying of `github_auth0_token` to `VoiceRepo` to use either use `GitHub.connectAnonymously()` or `GitHub.connectUsingOAuth()`