### PR TITLE
Abn digits keyboard

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/frontend/Tokenizer.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/Tokenizer.java
@@ -187,20 +187,22 @@ public class Tokenizer {
         // for all kinds of punctuation we need to insert spaces at the correct positions
         // Patterns
         String processedToken = token;
-        String insertSpaceAfterAnywhere = "([(\\[{\\-_,])";
-        String insertSpaceBeforeAnywhere = "([)\\[}\\-_,])";
-        String insertSpaceAfterIfBeginning = "^(\")(.+)";
-        String insertSpaceBeforeIfEnd = "(.+)([\":,.!?])$";
-        String insertSpaceBeforeIfEndAndPunct = "(.+)([\":,.!?])(\\s[\":,.!?])$";
+        // Matches all kinds of opening parentheses and some punctuation
+        // Example: "text in (parenthesis)" "a,b,c"
+        String insertSpaceAfterAnywhere = "([(\\[{\\-_,\"?!])";
+        // Matches all kinds of closing parentheses and some punctuation
+        // Example: "text in (parenthesis)" "a,b,c"
+        String insertSpaceBeforeAnywhere = "([)\\]}\\-_,\"?!])";
+        // Matches a token ending with ':' or '.'. We don't want to interfere with tokens
+        // containing these chars within, that is the task of the normalizer, e.g. urls, etc.
+        String insertSpaceBeforeIfEnd = "(.+)([:.])$";
 
         // replacements
         processedToken = processedToken.replaceAll(insertSpaceAfterAnywhere, "$1 ");
         processedToken = processedToken.replaceAll(insertSpaceBeforeAnywhere, " $1");
-        processedToken = processedToken.replaceAll(insertSpaceAfterIfBeginning, "$1" + " " + "$2");
         processedToken = processedToken.replaceAll(insertSpaceBeforeIfEnd, "$1" + " " + "$2");
-        processedToken = processedToken.replaceAll(insertSpaceBeforeIfEndAndPunct, "$1" + " " + "$2$3");
-
-        return processedToken.replaceAll("\\s+", " ");
+      
+        return processedToken.replaceAll("\\s+", " ").trim();
     }
 
     /* We assume 'token' contains some non-alphabetic characters and we test

--- a/app/src/main/java/com/grammatek/simaromur/frontend/Tokenizer.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/Tokenizer.java
@@ -176,7 +176,6 @@ public class Tokenizer {
                 || token.endsWith(" :"));
     }
 
-
     //If a token contains some other character(s) than alphabetic characters, we take a closer look.
     private String processSpecialCharacters(String token) {
 
@@ -188,20 +187,20 @@ public class Tokenizer {
         // for all kinds of punctuation we need to insert spaces at the correct positions
         // Patterns
         String processedToken = token;
-        String insertSpaceAfterAnywhere = "(.*)([(\\[{\\-_])(.*)";
-        String insertSpaceBeforeAnywhere = "(.+)([)\\[}\\-_])(.*)";
+        String insertSpaceAfterAnywhere = "([(\\[{\\-_,])";
+        String insertSpaceBeforeAnywhere = "([)\\[}\\-_,])";
         String insertSpaceAfterIfBeginning = "^(\")(.+)";
         String insertSpaceBeforeIfEnd = "(.+)([\":,.!?])$";
         String insertSpaceBeforeIfEndAndPunct = "(.+)([\":,.!?])(\\s[\":,.!?])$";
 
         // replacements
-        processedToken = processedToken.replaceAll(insertSpaceAfterAnywhere, "$1$2" + " " + "$3");
-        processedToken = processedToken.replaceAll(insertSpaceBeforeAnywhere, "$1" + " " + "$2$3");
+        processedToken = processedToken.replaceAll(insertSpaceAfterAnywhere, "$1 ");
+        processedToken = processedToken.replaceAll(insertSpaceBeforeAnywhere, " $1");
         processedToken = processedToken.replaceAll(insertSpaceAfterIfBeginning, "$1" + " " + "$2");
         processedToken = processedToken.replaceAll(insertSpaceBeforeIfEnd, "$1" + " " + "$2");
         processedToken = processedToken.replaceAll(insertSpaceBeforeIfEndAndPunct, "$1" + " " + "$2$3");
 
-        return processedToken;
+        return processedToken.replaceAll("\\s+", " ");
     }
 
     /* We assume 'token' contains some non-alphabetic characters and we test
@@ -216,7 +215,7 @@ public class Tokenizer {
         if (token.matches("\\d+\\.?"))
             return false;
         // a more complex combination of digits and punctuations, e.g. dates and large numbers
-        if (token.matches("(\\d+[.,:]\\d+)+[,.]?"))
+        if (token.matches("(\\d+[.,:]\\d+)+[,.]?%?"))
             return false;
         // telephone number, don't split on hyphen
         if (token.matches("\\d{3}-?\\d{4}"))
@@ -235,5 +234,4 @@ public class Tokenizer {
             return true;
         return mAbbreviationsNonending.contains(token.toLowerCase());
     }
-
 }

--- a/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
+++ b/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
@@ -28,11 +28,11 @@ public class NormalizationManagerTest {
 
     @Test
     public void processTest() {
-        String input = "sjö ,p,k,r,s";
+        String input = "Mynd / elg@vf.is";
         NormalizationManager manager = new NormalizationManager(context);
         String processed = manager.process(input);
         System.out.println(processed);
-        assertEquals("sjö , p , k , r , s .",
+        assertEquals("mynd skástrik e l g hjá v f punktur is .",
                 processed);
     }
 

--- a/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
+++ b/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
@@ -28,11 +28,11 @@ public class NormalizationManagerTest {
 
     @Test
     public void processTest() {
-        String input = "Álfur P er bestur";
+        String input = "sjö ,p,k,r,s";
         NormalizationManager manager = new NormalizationManager(context);
         String processed = manager.process(input);
         System.out.println(processed);
-        assertEquals("álfur p er bestur .",
+        assertEquals("sjö , p , k , r , s .",
                 processed);
     }
 
@@ -165,6 +165,7 @@ public class NormalizationManagerTest {
         testSentences.put("© grammatek", "höfundarréttur grammatek .");
         testSentences.put("Álfur P er bestur", "álfur p er bestur .");
         testSentences.put("Það bíður pk eftir þér", "það bíður pakki eftir þér .");
+        testSentences.put("sjö ,p,k,r,s", "sjö , p , k , r , s .");
 
         return testSentences;
     }


### PR DESCRIPTION
Fixed the tokenization of the digits keyboard (the telephone keyboard).

The letters at each digit button are deliverd comma separated from the service, example: 
`8 ,t,u,v`

The bug in the tokenizer was that it only inserted a space around the last comma, so the g2p input still contained the commas "glued" to the letters.
Fixed, so now the g2p input looks like:
`átta , t , u , v` and the final input to the TTS system: `au h t a §sp t_h j E: §sp Y: §sp v a f`

All previous tests in the `NormalizationManagerTest` passed.
