### PR TITLE
Add more configuration settings …

### DIFF
--- a/app/src/main/assets/config.properties
+++ b/app/src/main/assets/config.properties
@@ -1,5 +1,15 @@
-# This file can be used to set various properties for the app
+# This file is used to set various properties for the app
 
 # Credentials for github to circumvent the 60 requests per hour limit
 # set a token for your account here to increase the limit to 5000 requests per hour
 github_auth0_token =
+
+# The following entries can be used for influencing the behaviour of voice caching
+
+# if this is set to true, all cached items are deleted after playing audio, this should generally
+# only be enabled for debugging purposes
+rm_cache_item_after_playing = false
+
+# if this is set to true, fast voices are not cached. A fast voice is a voice that is
+# determined by its rtf. All rtf values above 20 are considered fast.
+rm_cache_item_for_fast_voices = false

--- a/app/src/main/assets/config.properties
+++ b/app/src/main/assets/config.properties
@@ -12,4 +12,4 @@ rm_cache_item_after_playing = false
 
 # if this is set to true, fast voices are not cached. A fast voice is a voice that is
 # determined by its rtf. All rtf values above 20 are considered fast.
-rm_cache_item_for_fast_voices = false
+rm_cache_item_for_fast_voices = true

--- a/app/src/main/java/com/grammatek/simaromur/TTSProcessingResult.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSProcessingResult.java
@@ -64,6 +64,13 @@ public class TTSProcessingResult {
     }
 
     /**
+     * Returns true if everythin is ok, false otherwise.
+     */
+    public boolean isOk() {
+        return !isError();
+    }
+
+    /**
      * Returns true if the com.grammatek.simaromur.TTSProcessingResult is an error state.
      *
      * @return true if the com.grammatek.simaromur.TTSProcessingResult is an error state, false otherwise.


### PR DESCRIPTION
Add configurtion settings `rm_cache_item_after_playing`, `rm_cache_item_for_fast_voices`

These are foremost helpers for debugging so that we don't need to manually delete the application data, if we try out new versions of frontend and/or voice audio.

But of course there is no need for caching in case the voice generation on the phone is fast enough, so we could also activate rm_cache_item_for_fast_voices in combination with a good `RTF` setting even for production.
