### PR TITLE
Revamp voice version handling and cache cleanup

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/ApiDbUtil.java
+++ b/app/src/main/java/com/grammatek/simaromur/ApiDbUtil.java
@@ -74,8 +74,13 @@ public class ApiDbUtil {
         // create new voices from our list of unknown voices
         for (VoiceResponse av:newApiVoices) {
             Log.v(LOG_TAG, "Creating new voice from " + av);
+            // TODO: We have no version info yet, use v0
+            final String dummyVersion="v0" ;
+
+            Log.w(LOG_TAG, "No version info for voice " + av.VoiceId + " yet, using "
+                    + dummyVersion);
             Voice voice = new Voice(av.Name, av.VoiceId, av.Gender, av.LanguageCode, av.LanguageName,
-                    "", Voice.TYPE_NETWORK, "", "", "", "", 0);
+                    "", Voice.TYPE_NETWORK, "", "", dummyVersion, "", 0);
             Log.v(LOG_TAG, "New contents: " + voice);
             try {
                 mVoiceDao.insertVoice(voice);

--- a/app/src/main/java/com/grammatek/simaromur/VoiceViewModel.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceViewModel.java
@@ -66,7 +66,7 @@ public class VoiceViewModel extends AndroidViewModel {
                               TTSAudioControl.AudioFinishedObserver finishedObserver) {
         switch (voice.type) {
             case Voice.TYPE_NETWORK:
-                mRepository.startNetworkSpeak(voice.internalName, item, voice.languageCode, finishedObserver);
+                mRepository.startNetworkSpeak(voice.internalName, voice.version, item, voice.languageCode, finishedObserver);
                 break;
             case Voice.TYPE_TORCH:
             case Voice.TYPE_FLITE:  // FALLTHROUGH

--- a/app/src/main/java/com/grammatek/simaromur/cache/UtteranceCacheManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/cache/UtteranceCacheManager.java
@@ -631,7 +631,11 @@ public class UtteranceCacheManager {
      */
     @NonNull
     public static String buildVoiceKey(String voiceName, String voiceVersion) {
-        return voiceName + ":" + voiceVersion;
+        assert(!voiceName.isEmpty());
+        assert(!voiceVersion.isEmpty());
+        final String key = voiceName + ":" + voiceVersion;
+        Log.v(LOG_TAG, "buildVoiceKey(): " + key);
+        return key;
     }
 
     /**

--- a/app/src/main/java/com/grammatek/simaromur/db/ApplicationDb.java
+++ b/app/src/main/java/com/grammatek/simaromur/db/ApplicationDb.java
@@ -22,7 +22,7 @@ import java.util.List;
 )
 public abstract class ApplicationDb extends RoomDatabase {
     private final static String LOG_TAG = "Simaromur_" + ApplicationDb.class.getSimpleName();
-    static final int LATEST_VERSION = 5;
+    static final int LATEST_VERSION = 7;
     private static volatile ApplicationDb INSTANCE;
 
     public abstract AppDataDao appDataDao();
@@ -58,8 +58,24 @@ public abstract class ApplicationDb extends RoomDatabase {
     static public final Migration MIGRATION_4_5 = new Migration(4, 5){  // v4 => 5
         @Override
         public void migrate(SupportSQLiteDatabase database){
-            Log.v(LOG_TAG, "MIGRATION_5_6");
+            Log.v(LOG_TAG, "MIGRATION_4_5");
             database.execSQL("DELETE FROM voice_table WHERE type = 'tiro'");
+        }
+    };
+    static public final Migration MIGRATION_5_6 = new Migration(5, 6){  // v5 => 6
+        @Override
+        public void migrate(SupportSQLiteDatabase database){
+            Log.v(LOG_TAG, "MIGRATION_5_6");
+            // create a dummy version for all empty version info
+            database.execSQL("UPDATE voice_table SET version = 'v0' WHERE version = ''");
+        }
+    };
+    static public final Migration MIGRATION_6_7 = new Migration(6, 7){  // v6 => 7
+        @Override
+        public void migrate(SupportSQLiteDatabase database){
+            Log.v(LOG_TAG, "MIGRATION_6_7");
+            // create a dummy version for all empty version info
+            database.execSQL("UPDATE voice_table SET url = 'https://api.grammatek.com/tts/v0' WHERE type = 'network'");
         }
     };
     public static ApplicationDb getDatabase(final Context context) {
@@ -69,7 +85,7 @@ public abstract class ApplicationDb extends RoomDatabase {
                 if (INSTANCE == null) {
                     INSTANCE = Room.databaseBuilder(context.getApplicationContext(),
                             ApplicationDb.class, "application_db")
-                            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+                            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
                             // Wipes and rebuilds instead of migrating if no Migration object.
                             .fallbackToDestructiveMigration()
                             .allowMainThreadQueries()

--- a/app/src/main/java/com/grammatek/simaromur/db/Voice.java
+++ b/app/src/main/java/com/grammatek/simaromur/db/Voice.java
@@ -141,6 +141,10 @@ public class Voice {
         }
         this.url = url;
         this.downloadPath = downloadPath;
+        if (version.isEmpty()) {
+            throw new AssertionError("Given voice version (" + version + ") not valid !");
+        }
+
         this.version = version;
         this.md5Sum = md5Sum;
         this.size = size;

--- a/app/src/main/java/com/grammatek/simaromur/device/TTSEngineController.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/TTSEngineController.java
@@ -246,9 +246,8 @@ public class TTSEngineController {
 
             // retrieve audio from utterance cache, if available
             UtteranceCacheManager ucm =  App.getAppRepository().getUtteranceCache();
-            // TODO: voiceVersion parameter is not taken into account yet !
             final List<byte[]> audioBuffers =
-                    ucm.getAudioForUtterance(item.getUtterance(), mCurrentVoice.InternalName, "v1");
+                    ucm.getAudioForUtterance(item.getUtterance(), mCurrentVoice.InternalName, voice.Version);
             if (shouldStop()) {
                 Log.v(LOG_SPEAK_TASK_TAG, "run(): shouldStop(2): true");
                 return;
@@ -305,7 +304,6 @@ public class TTSEngineController {
             }
             bytes = mEngine.SpeakToPCM(phonemeEntry.getSymbols());
 
-            // TODO: voiceVersion parameter is not taken into account yet !
             SampleRate sampleRate;
             if (mEngine.GetNativeSampleRate() == 22050) {
                 sampleRate = SAMPLE_RATE_22KHZ;
@@ -315,7 +313,7 @@ public class TTSEngineController {
                 throw new IllegalStateException("Unknown sample rate: " + mEngine.GetNativeSampleRate());
             }
             final VoiceAudioDescription vad = UtteranceCacheManager.newAudioDescription(AUDIO_FMT_PCM,
-                    sampleRate, bytes.length, mCurrentVoice.InternalName, "v1");
+                    sampleRate, bytes.length, mCurrentVoice.InternalName, mCurrentVoice.Version);
             if (bytes.length == 0) {
                 Log.w(LOG_SPEAK_TASK_TAG, "synthesizeSpeech(): No audio generated ?!");
                 return null;

--- a/app/src/main/java/com/grammatek/simaromur/device/pojo/DeviceVoice.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/pojo/DeviceVoice.java
@@ -53,6 +53,7 @@ public class DeviceVoice {
         this.LanguageName = languageName;
         this.Gender = gender;
         this.Type = type;
+        assert(version != null && version.length() > 0);
         this.Version = version;
         try
         {

--- a/app/src/main/java/com/grammatek/simaromur/network/api/SpeakController.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/api/SpeakController.java
@@ -16,6 +16,7 @@ import androidx.annotation.NonNull;
 import com.grammatek.simaromur.App;
 import com.grammatek.simaromur.AppRepository;
 import com.grammatek.simaromur.TTSRequest;
+import com.grammatek.simaromur.TTSService;
 import com.grammatek.simaromur.audio.AudioObserver;
 import com.grammatek.simaromur.cache.AudioFormat;
 import com.grammatek.simaromur.cache.CacheItem;
@@ -24,6 +25,7 @@ import com.grammatek.simaromur.cache.SampleRate;
 import com.grammatek.simaromur.cache.Utterance;
 import com.grammatek.simaromur.cache.UtteranceCacheManager;
 import com.grammatek.simaromur.cache.VoiceAudioDescription;
+import com.grammatek.simaromur.db.VoiceDao;
 import com.grammatek.simaromur.network.api.pojo.SpeakRequest;
 
 import org.jetbrains.annotations.NotNull;
@@ -206,15 +208,13 @@ public class SpeakController implements Callback<ResponseBody> {
                 if (utterance.getPhonemesCount() > 0) {
                     // use first phoneme entry of the cache item
                     PhonemeEntry phonemeEntry = utterance.getPhonemesList().get(0);
-                    // TODO:- voiceVersion parameter is not taken into account yet !
-                    //      - is the internal name of the voice model the same as we use here ?
-                    //          this should be consistent with the on-device voice handling
-                    String voiceName = mRequest.VoiceId;
-                    SampleRate sampleRate = getSampleRate();
-                    AudioFormat audioFormat = getAudioFormat();
+                    final String voiceName = mRequest.VoiceId;
+                    final String version = App.getAppRepository().getVersionOfVoice(voiceName);
+                    final SampleRate sampleRate = getSampleRate();
+                    final AudioFormat audioFormat = getAudioFormat();
                     final VoiceAudioDescription vad =
                             UtteranceCacheManager.newAudioDescription(audioFormat, sampleRate,
-                                    data.length, voiceName, "v1");
+                                    data.length, voiceName, version);
                     if (data.length == 0) {
                         Log.w(LOG_TAG, "synthesizeSpeech(): No audio generated ?!");
                     } else {

--- a/app/src/test/java/com/grammatek/simaromur/TestRoomDbMigration.java
+++ b/app/src/test/java/com/grammatek/simaromur/TestRoomDbMigration.java
@@ -88,18 +88,45 @@ public class TestRoomDbMigration {
 
     @Test
     public void migrationFrom4To5() throws IOException {
-        // Create the database in version 3, then migrate to 4
+        // Create the database in version 4, then migrate to 5
         SupportSQLiteDatabase db =
-                testHelper.createDatabase(TEST_DB_NAME, 3);
+                testHelper.createDatabase(TEST_DB_NAME, 4);
         db.execSQL("INSERT INTO app_data_table VALUES (1, '2', 1, '/flite/voices', 'today'," +
-                " '/sim/voices', 'today', 1)");
+                " '/sim/voices', 'today', 1, 1)");
 
         db.execSQL("INSERT INTO voice_table VALUES (1, 'Álfur', 'male', 'Alfur', 'is-IS', 'Íslenska(icelandic)'," +
                 " '', 'network', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
         db.close();
-        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 4, true, ApplicationDb.MIGRATION_3_4);
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 5, true, ApplicationDb.MIGRATION_4_5);
     }
 
+    @Test
+    public void migrationFrom5To6() throws IOException {
+        // Create the database in version 5, then migrate to 6
+        SupportSQLiteDatabase db =
+                testHelper.createDatabase(TEST_DB_NAME, 5);
+        db.execSQL("INSERT INTO app_data_table VALUES (1, '2', 1, '/flite/voices', 'today'," +
+                " '/sim/voices', 'today', 1, 1)");
+
+        db.execSQL("INSERT INTO voice_table VALUES (1, 'Álfur', 'male', 'Alfur', 'is-IS', 'Íslenska(icelandic)'," +
+                " '', 'network', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
+        db.close();
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 6, true, ApplicationDb.MIGRATION_5_6);
+    }
+
+    @Test
+    public void migrationFrom6To7() throws IOException {
+        // Create the database in version 6, then migrate to 7
+        SupportSQLiteDatabase db =
+                testHelper.createDatabase(TEST_DB_NAME, 6);
+        db.execSQL("INSERT INTO app_data_table VALUES (1, '2', 1, '/flite/voices', 'today'," +
+                " '/sim/voices', 'today', 1, 1)");
+
+        db.execSQL("INSERT INTO voice_table VALUES (1, 'Álfur', 'male', 'Alfur', 'is-IS', 'Íslenska(icelandic)'," +
+                " '', 'network', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
+        db.close();
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 7, true, ApplicationDb.MIGRATION_6_7);
+    }
     @Test
     public void TestDBV2() throws IOException {
         // Create DB in V2
@@ -161,9 +188,39 @@ public class TestRoomDbMigration {
 
     @Test
     public void TestDBV5() throws IOException {
-        // Create DB in V4
+        // Create DB in V5
         SupportSQLiteDatabase db =
                 testHelper.createDatabase(TEST_DB_NAME, 5);
+        db.execSQL("INSERT INTO app_data_table VALUES (1, '3', 2, '/flite/voices', 'today'," +
+                " '/sim/voices', 'today', 1, 1)");
+
+        db.execSQL("UPDATE app_data_table SET privacy_info_dialog_accepted = 0, crash_lytics_user_consent_accepted = 0 WHERE appDataId = 1");
+
+        db.execSQL("INSERT INTO voice_table VALUES (1, 'Álfur', 'male', 'Alfur', 'is-IS', 'Íslenska(icelandic)'," +
+                " '', 'network', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
+
+        db.close();
+    }
+    @Test
+    public void TestDBV6() throws IOException {
+        // Create DB in V5
+        SupportSQLiteDatabase db =
+                testHelper.createDatabase(TEST_DB_NAME, 6);
+        db.execSQL("INSERT INTO app_data_table VALUES (1, '3', 2, '/flite/voices', 'today'," +
+                " '/sim/voices', 'today', 1, 1)");
+
+        db.execSQL("UPDATE app_data_table SET privacy_info_dialog_accepted = 0, crash_lytics_user_consent_accepted = 0 WHERE appDataId = 1");
+
+        db.execSQL("INSERT INTO voice_table VALUES (1, 'Álfur', 'male', 'Alfur', 'is-IS', 'Íslenska(icelandic)'," +
+                " '', 'network', 'now', 'now', 'http://someurl', 'downloadpath', 'API1', 'nomd5sum', 0)");
+
+        db.close();
+    }
+    @Test
+    public void TestDBV7() throws IOException {
+        // Create DB in V5
+        SupportSQLiteDatabase db =
+                testHelper.createDatabase(TEST_DB_NAME, 7);
         db.execSQL("INSERT INTO app_data_table VALUES (1, '3', 2, '/flite/voices', 'today'," +
                 " '/sim/voices', 'today', 1, 1)");
 


### PR DESCRIPTION
This is a bug fix for deleting cached utterances in case of fast voices. Because of the calculation of the RTF (realtime factor) even for the case of reading from cached utterances, any cache item was deleted after being played, if the setting `rm_cache_item_for_fast_voices` was set to true, which is the default.
Furthermore, the missing version info for the cache item caused cache handling bugs that took the version info into account.

- don't delete cache items in case it's already inside the cache
- add sanity check for RTF-calculations > 500, which are a hint on either cancellations or problems and don't delete the cache item in that case
- if the time measured between enquing a processing request and the processing response is 0, don't calculate RTF as infinity
- always add the version of the voice for any cache item
- add dummy version info v0 for network voices
- migrate any existing network voice version in the db to v0
- assert on missing version info
- add new db migrations 6->7 for the voices table
- fix missing migration tests