### PR TITLE
Fix ttsmanager resource leak

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/AppRepository.java
+++ b/app/src/main/java/com/grammatek/simaromur/AppRepository.java
@@ -70,9 +70,9 @@ public class AppRepository {
     private final ApiDbUtil mApiDbUtil;
     private final AssetVoiceManager mAVM;
     private final DownloadVoiceManager mDVM;
-    // audio cache low/high watermark: 128/256MB, @todo: make configurable
-    private static final long CacheLowWatermark = 128 * 1024 * 1024;
-    private static final long CacheHighWatermark = 2 * CacheLowWatermark;
+    // audio cache low/high watermark: 48/72MB, @todo: make configurable
+    private static final long CacheLowWatermark = 48 * 1024 * 1024;
+    private static final long CacheHighWatermark = (long) (1.5 * CacheLowWatermark);
     private final UtteranceCacheManager mUtteranceCacheManager;
     // in TTSService.onSynthesizeText() we receive items of this queue and send them from either
     // a.) TTS worker threads or b.) via TTSService.onStop()

--- a/app/src/main/java/com/grammatek/simaromur/TTSManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSManager.java
@@ -207,7 +207,7 @@ public class TTSManager extends Activity implements OnItemClickListener, TextToS
         if (requestCode == MY_DATA_CHECK_CODE) {
             // Create the TTS instance, this also pulls up our TTSService. Anywhere we use
             // this object, we must always check beforehand mTtsClient != null.
-            mTtsClient = new TextToSpeech(this, this,
+            mTtsClient = new TextToSpeech(getApplicationContext(), this,
                     getApplicationContext().getPackageName());
         }
     }

--- a/app/src/main/java/com/grammatek/simaromur/TTSService.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSService.java
@@ -1,6 +1,7 @@
 package com.grammatek.simaromur;
 
 import android.media.AudioFormat;
+import android.os.Bundle;
 import android.provider.Settings;
 import android.speech.tts.SynthesisCallback;
 import android.speech.tts.SynthesisRequest;
@@ -121,6 +122,8 @@ public class TTSService extends TextToSpeechService {
         String variant = request.getVariant();
         String text = request.getCharSequenceText().toString();
         String voiceName = request.getVoiceName();
+        int callerUid = request.getCallerUid();
+        Bundle params = request.getParams();
         // we will get speechrate and pitch from the settings,
         // but in case the retrieval of the values fails, let's get the values from the request first.
         int speechrate = request.getSpeechRate();
@@ -132,8 +135,9 @@ public class TTSService extends TextToSpeechService {
             ex.printStackTrace();
         }
         Log.v(LOG_TAG, "onSynthesizeText: " + text);
-        Log.v(LOG_TAG, "onSynthesizeText: (" + language + "/" + country + "/" + variant +
-                "), speed: " + speechrate + " pitch: " + pitch);
+        Log.v(LOG_TAG, "onSynthesizeText: (" + language + "/" + country + "/" + variant
+                + "), callerUid: " + callerUid + " speed: " + speechrate + " pitch: " + pitch
+                + " bundle: " + params);
 
         // if cache item for text already exists: retrieve it, otherwise create a new cache
         // item and save it into cache, then test one-by-one availability of every single


### PR DESCRIPTION
- fixed a resouce leak found on Samsung A152 device (haven't seen this on the Pixel 6 before)
- reduce the max audio cache size from 256MB to 72MB
- log some more info about TTS request in case `onSynthesizeText()` is called