### PR TITLE
Revamp voice deletion & voice presence for on-device downloadable voices

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/TTSService.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSService.java
@@ -19,6 +19,7 @@ import com.grammatek.simaromur.network.ConnectionCheck;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -486,17 +487,22 @@ public class TTSService extends TextToSpeechService {
         List<Voice> announcedVoiceList = new ArrayList<>();
 
         for (final com.grammatek.simaromur.db.Voice voice : mRepository.getCachedVoices()) {
-            int quality = Voice.QUALITY_NORMAL;
+            int quality = Voice.QUALITY_VERY_LOW;
             int latency = Voice.LATENCY_LOW;
             boolean needsNetwork = false;
             Set<String> features = new HashSet<>();
 
             if (voice.type.equals(com.grammatek.simaromur.db.Voice.TYPE_NETWORK)) {
                 latency = Voice.LATENCY_VERY_HIGH;
+                quality = Voice.QUALITY_HIGH;
                 features.add(TextToSpeech.Engine.KEY_FEATURE_NETWORK_RETRIES_COUNT);
                 needsNetwork = true;
             } else if (voice.type.equals(com.grammatek.simaromur.db.Voice.TYPE_TORCH)) {
+                quality = Voice.QUALITY_VERY_HIGH;
                 latency = Voice.LATENCY_VERY_HIGH;
+            }
+            if (voice.needsDownload()) {
+                features.add(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED);
             }
             Voice ttsVoice = new Voice(voice.name, voice.getLocale(), quality, latency,
                     needsNetwork, features);

--- a/app/src/main/java/com/grammatek/simaromur/VoiceListAdapter.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceListAdapter.java
@@ -1,6 +1,7 @@
 package com.grammatek.simaromur;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -47,8 +48,10 @@ public class VoiceListAdapter extends RecyclerView.Adapter<VoiceListAdapter.Voic
             holder.voiceTypeItemView.setText(App.getContext().getResources().getString(R.string.type_network));
         } else if (current.needsDownload()) {
             holder.voiceTypeItemView.setText(App.getContext().getResources().getString(R.string.type_local_downloaded));
+            holder.voiceTypeItemView.setTextColor(Color.YELLOW);
         } else {
             holder.voiceTypeItemView.setText(App.getContext().getResources().getString(R.string.type_local));
+            holder.voiceTypeItemView.setTextColor(Color.GREEN);
         }
     }
 

--- a/app/src/main/java/com/grammatek/simaromur/VoiceManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceManager.java
@@ -40,6 +40,30 @@ public class VoiceManager extends AppCompatActivity {
         // in the foreground.
         voiceViewModel.getAllVoices().observe(this, voices -> {
             Log.v(LOG_TAG, "onChanged - voices size: " + voices.size());
+            // sort voices by their type and then their internal name
+            voices.sort((v1, v2) -> {
+                if (v1.type.equals(v2.type)) {
+                    return v1.internalName.compareTo(v2.internalName);
+                } else {
+                    // we want to have the type sorted in the order of
+                    // the following list:
+                    // 1. "flite"
+                    // 2. "torchscript"
+                    // 3. "network"
+                    if (v1.type.equals("flite")) {
+                        return -1;
+                    } else if (v2.type.equals("flite")) {
+                        return 1;
+                    } else if (v1.type.equals("torchscript")) {
+                        return -1;
+                    } else if (v2.type.equals("torchscript")) {
+                        return 1;
+                    } else {
+                        return 0;
+                    }
+                }
+            });
+
             // Update cached voices
             adapter.setVoices(voices);
         });

--- a/app/src/main/java/com/grammatek/simaromur/VoiceMoreDialogFragment.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceMoreDialogFragment.java
@@ -1,0 +1,107 @@
+package com.grammatek.simaromur;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class VoiceMoreDialogFragment extends DialogFragment {
+    private final static String LOG_TAG = "Simaromur_" + VoiceMoreDialogFragment.class.getSimpleName();
+    // the listener is passed via onAttach()
+    NoticeDialogListener m_listener;
+    int m_itemId = -1;
+    Button m_positiveButton;
+    // TODO: preparation for updatable voices
+    boolean m_isUpdateAvailable = false;
+
+    VoiceMoreDialogFragment(boolean isUpdateAvailable) {
+        m_isUpdateAvailable = isUpdateAvailable;
+    }
+
+    /* The activity that creates an instance of this dialog fragment must
+     * implement this interface in order to receive event callbacks.
+     * Each method passes the DialogFragment in case the host needs to query it. */
+    public interface NoticeDialogListener {
+        public void onDialogPositiveClick(DialogFragment dialog, int itemId);
+        public void onDialogNegativeClick(DialogFragment dialog);
+    }
+
+
+    // Override the Fragment.onAttach() method to instantiate the NoticeDialogListener
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        // Verify that the host activity implements the callback interface
+        try {
+            m_listener = (NoticeDialogListener) context;
+        } catch (ClassCastException e) {
+            // The activity doesn't implement the interface, throw exception
+            throw new ClassCastException(LOG_TAG + ": Activity must implement NoticeDialogListener");
+        }
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        int checkedItem = -1;
+        int arrayId = m_isUpdateAvailable ? R.array.voice_more_options_array : R.array.voice_more_options_wo_update;
+        builder.setTitle(R.string.voice_more_title)
+                .setCancelable(false)
+                .setSingleChoiceItems(arrayId, checkedItem, (dialog, which) -> {
+                    // 'which' contains the index position of selected item
+                    Log.v(LOG_TAG, "which: " + which);
+                    switch (which) {
+                        case 0:     // FALLTHROUGH
+                        case 1:
+                            m_itemId = which;
+                            m_positiveButton.setEnabled(true);
+                            break;
+                        default:
+                            Log.w(LOG_TAG, "Unknown option: " + which);
+                            break;
+                    }
+                })
+                .setPositiveButton(R.string.ok, (dialog, id) -> {
+                    // Send the positive button event back to the host activity
+                    m_listener.onDialogPositiveClick(VoiceMoreDialogFragment.this, m_itemId);
+                })
+                .setNegativeButton(R.string.cancel, (dialog, id) -> {
+                    // Ok, user cancelled the dialog
+                    m_listener.onDialogNegativeClick(VoiceMoreDialogFragment.this);
+                });
+        // Create the AlertDialog object and return it
+        return builder.create();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        AlertDialog d = (AlertDialog) getDialog();
+        assert d != null;
+        m_positiveButton = d.getButton(Dialog.BUTTON_POSITIVE);
+        m_positiveButton.setEnabled(false);
+
+        ListView listView = d.getListView();
+        Log.v(LOG_TAG, "dialog adapter: " + listView.getAdapter());
+
+        final ListAdapter items = d.getListView().getAdapter();
+        if (items.getCount() != 0) {
+            Log.w(LOG_TAG, "Items: " + items.getCount());
+        } else {
+            Log.w(LOG_TAG, "No items in list");
+        }
+    }
+
+}

--- a/app/src/main/java/com/grammatek/simaromur/utils/AsyncThread.java
+++ b/app/src/main/java/com/grammatek/simaromur/utils/AsyncThread.java
@@ -29,15 +29,11 @@ public abstract class AsyncThread {
         onPreExecute();
         executors.execute(() -> {
             Thread.currentThread().setName(threadName);
-            Log.v(LOG_TAG, threadName + ": before doInBackground()");
             doInBackground();
-            Log.v(LOG_TAG, threadName + ": after doInBackground()");
             new Handler(Looper.getMainLooper()).post(new Runnable() {
                 @Override
                 public void run() {
-                    Log.v(LOG_TAG, "UI: before onPostExecute()");
                     onPostExecute();
-                    Log.v(LOG_TAG, "UI: after onPostExecute()");
                 }
             });
         });
@@ -45,9 +41,7 @@ public abstract class AsyncThread {
 
     public void execute(String aThreadName) {
         threadName = aThreadName;
-        Log.v(LOG_TAG, "UI: before startBackground()");
         startBackground();
-        Log.v(LOG_TAG, "UI: after startBackground()");
     }
 
     public void shutdown() {

--- a/app/src/main/res/drawable/more_vert_48px.xml
+++ b/app/src/main/res/drawable/more_vert_48px.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M24,40Q23,40 22.3,39.3Q21.6,38.6 21.6,37.6Q21.6,36.6 22.3,35.9Q23,35.2 24,35.2Q25,35.2 25.7,35.9Q26.4,36.6 26.4,37.6Q26.4,38.6 25.7,39.3Q25,40 24,40ZM24,26.4Q23,26.4 22.3,25.7Q21.6,25 21.6,24Q21.6,23 22.3,22.3Q23,21.6 24,21.6Q25,21.6 25.7,22.3Q26.4,23 26.4,24Q26.4,25 25.7,25.7Q25,26.4 24,26.4ZM24,12.8Q23,12.8 22.3,12.1Q21.6,11.4 21.6,10.4Q21.6,9.4 22.3,8.7Q23,8 24,8Q25,8 25.7,8.7Q26.4,9.4 26.4,10.4Q26.4,11.4 25.7,12.1Q25,12.8 24,12.8Z"/>
+</vector>

--- a/app/src/main/res/layout/activity_voice_info.xml
+++ b/app/src/main/res/layout/activity_voice_info.xml
@@ -119,6 +119,42 @@
         app:layout_constraintStart_toStartOf="@+id/textView2"
         app:layout_constraintTop_toBottomOf="@+id/textView2" />
 
+    <androidx.cardview.widget.CardView
+        android:id="@+id/moreOptionsBackground"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:cardElevation="0dp"
+        android:layout_marginEnd="30dp"
+        app:cardBackgroundColor="@color/colorPrimaryLight"
+        app:cardCornerRadius="10dp"
+        app:layout_constraintBottom_toBottomOf="@+id/textView8"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.923"
+        app:layout_constraintStart_toEndOf="@id/imageStatus"
+        app:layout_constraintTop_toTopOf="@+id/textView8">
+
+        <ImageView
+            android:id="@+id/moreOptions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center|top"
+            android:layout_marginHorizontal="5dp"
+            android:layout_marginBottom="3dp"
+            android:rotation="90"
+            android:src="@drawable/more_vert_48px"
+            app:tint="@color/white" />
+
+        <TextView
+            android:id="@+id/moreOptionsText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/more"
+            android:layout_marginBottom="2dp"
+            android:layout_gravity="center|bottom"
+            android:textColor="@color/white" />
+    </androidx.cardview.widget.CardView>
+
+
     <ImageView
         android:id="@+id/imageStatus"
         android:layout_width="0dp"
@@ -126,11 +162,12 @@
         android:layout_marginEnd="24dp"
         android:contentDescription="@string/play_voice_title_description"
         app:layout_constraintBottom_toBottomOf="@+id/textView8"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/moreOptionsBackground"
         app:layout_constraintHorizontal_bias="0.923"
         app:layout_constraintStart_toStartOf="@+id/textViewType"
         app:layout_constraintTop_toTopOf="@+id/textView8"
         app:srcCompat="@drawable/ic_cloud_unavailable_solid" />
+
 
     <EditText
         android:id="@+id/speakable_text"
@@ -144,9 +181,11 @@
         android:importantForAutofill="no"
         android:inputType="textAutoCorrect|textMultiLine"
         android:orientation="vertical"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
         app:layout_constraintBottom_toTopOf="@+id/speak_button"
-        app:layout_constraintEnd_toEndOf="@+id/imageStatus"
-        app:layout_constraintStart_toStartOf="@+id/textView8"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textView8"
         tools:ignore="LabelFor" />
 

--- a/app/src/main/res/values-is-rIS/arrays.xml
+++ b/app/src/main/res/values-is-rIS/arrays.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array
+        name="voice_more_options_array" >
+            <item>uppfæra</item>
+            <item>eyða</item>
+    </string-array>
+    <string-array
+        name="voice_more_options_wo_update" >
+        <item>eyða</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values-is-rIS/strings.xml
+++ b/app/src/main/res/values-is-rIS/strings.xml
@@ -76,5 +76,12 @@
     <string name="downloading_voice">Sæki rödd…</string>
     <string name="downloading_progress">0%</string>
     <string name="unzipping_voice">Uppsetning á rödd…</string>
-    <string name="download_failed">Það fór eitthvað úrskeiðis, vinsamlegast reyndu aftur.</string>
+    <string name="sth_failed_try_again">Það fór eitthvað úrskeiðis, vinsamlegast reyndu aftur.</string>
+    <string name="more">Meira</string>
+    <string name="uninstall">Eyða rödd</string>
+    <string name="voice_more_title">Velja</string>
+    <string name="voice_is_newest">Nýjasta útgáfa nú þegar uppsett</string>
+    <string name="voice_deletion_title">Eyða rödd</string>
+    <string name="voice_deletion_q">Virkilega eyða rödd?</string>
+    <string name="voice_deletion_not_possible">Þú getur ekki eytt röddinni sem er valin, vinsamlegast veldu aðra rödd og reyndu aftur</string>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array
+        name="voice_more_options_array" >
+            <item>delete</item>
+            <item>update</item>
+    </string-array>
+    <string-array
+        name="voice_more_options_wo_update" >
+            <item>delete</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,9 +63,9 @@
     <string name="female">Female</string>
     <string name="icon_description">Please press an icon</string>
     <string name="type_local">Device Voice</string>
-    <string name="type_local_downloaded">Downloadable</string>
+    <string name="type_local_downloaded">Download</string>
     <string name="type_network">Network Voice</string>
-    <string name="do_download">Download voice</string>
+    <string name="do_download">Download</string>
     <string name="enter_text">Enter text here</string>
     <string name="cache">Cache</string>
     <string name="cache_cleared">Cache cleared</string>
@@ -76,5 +76,12 @@
     <string name="downloading_voice">Downloading voice…</string>
     <string name="downloading_progress">0%</string>
     <string name="unzipping_voice">Setting up voice…</string>
-    <string name="download_failed">Something went wrong, please try again.</string>
+    <string name="sth_failed_try_again">Something went wrong, please try again.</string>
+    <string name="more">More</string>
+    <string name="uninstall">Uninstall voice</string>
+    <string name="voice_more_title">Choose</string>
+    <string name="voice_is_newest">Latest version already installed</string>
+    <string name="voice_deletion_title">Delete voice</string>
+    <string name="voice_deletion_q">Really delete voice?</string>
+    <string name="voice_deletion_not_possible">You cannot delete the voice you are currently using, please select a different voice and try again</string>
 </resources>


### PR DESCRIPTION
- if downloadable voice is not yet downloaded, mark it for Android as `KEY_FEATURE_NOT_INSTALLED`. This makes it unplayable in the TTS Android settings and prevents any possible errors originating from there
- mark a not yet downloaded on-device voice yellow in VoiceListAdapter, and on-device voice which is ready to play with green color
- sort the list of voices in the order of their type and then their internal name, the type is sorted like this: `flite`, `torchscript`, `network`
- make the deletion process of the voice a radio-button dialog reachable via `...` next to the voice `Staða` and add `VoiceMoreDialogFragment` for a custom dialog. If the user presses delete, multiple checks are done:
   -  ask user for confirmation
   - If voice is  activated, inform user that it cannot be deleted and he has to select a different voice before retrying.
- when voice is deleted, show a progress spinner widget and a notice that the voice is currently being deleted. The same spinner is used as for the download voice part, but the text is changed dynamically. Because of this, we also need to set the text anew when downloading a voice with the appropriate message
- if the deletion is finished, show again the same voice info screen as if there hasn't been a previously downloaded voice
- varous smaller bug-fixes and documentation updates
- basing on Kristófers former commits

this closes #134 