### PR TITLE
Rework issues with downloadable voices and network availibility changes

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/VoiceManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceManager.java
@@ -39,7 +39,7 @@ public class VoiceManager extends AppCompatActivity {
         // The onChanged() method fires when the observed data changes and the activity is
         // in the foreground.
         voiceViewModel.getAllVoices().observe(this, voices -> {
-            Log.v(LOG_TAG, "onChanged - voices size: " + voices.size());
+            Log.v(LOG_TAG, "VoiceManager::onCreate::voiceViewModel.getAllVoices().observe - voices size: " + voices.size());
             // sort voices by their type and then their internal name
             voices.sort((v1, v2) -> {
                 if (v1.type.equals(v2.type)) {

--- a/app/src/main/java/com/grammatek/simaromur/device/SymbolsLvLIs.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/SymbolsLvLIs.java
@@ -87,7 +87,7 @@ public class SymbolsLvLIs {
         return sampa2VecInput;
     }
 
-    // Maps given sampa to labels/id used in the model
+    // Maps given ipa to labels/id used in the model
     private static int MapIPAToInt(String sampa) {
         Integer order = -1;
         order = IPASymbolMap.get(sampa);

--- a/app/src/main/java/com/grammatek/simaromur/device/pojo/DeviceVoice.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/pojo/DeviceVoice.java
@@ -9,6 +9,8 @@ import com.grammatek.simaromur.db.Voice;
 import com.grammatek.simaromur.network.remoteasset.VoiceFile;
 import com.grammatek.simaromur.network.remoteasset.VoiceInfo;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -140,5 +142,35 @@ public class DeviceVoice {
                 "",         // md5sum
                 0);                  // size
         // download path, md5sum and size are set later, when the file is downloaded
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        DeviceVoice other = (DeviceVoice) obj;
+        // compare Files via constructing List difference
+        List<DeviceVoiceFile> differences  = new ArrayList<>(other.Files);
+        differences.removeAll(Files);
+        boolean filesAreEqual = differences.isEmpty() && Files.size() == other.Files.size();
+        return filesAreEqual && InternalName.equals(other.InternalName)
+                && Version.equals(other.Version) && Residence.equals(other.Residence)
+                && Release.equals(other.Release);
+    }
+
+    public int hashCode() {
+        // you pick a hard-coded, randomly chosen, non-zero, odd number
+        // ideally different for each class
+        return new HashCodeBuilder(17, 37).
+                append(InternalName).
+                append(Version).
+                append(Residence).
+                append(Release).
+                append(Files).
+                toHashCode();
     }
 }

--- a/app/src/main/java/com/grammatek/simaromur/device/pojo/DeviceVoiceFile.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/pojo/DeviceVoiceFile.java
@@ -5,6 +5,8 @@ import androidx.annotation.NonNull;
 import com.google.gson.annotations.SerializedName;
 import com.grammatek.simaromur.network.remoteasset.VoiceFile;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 public class DeviceVoiceFile {
     @SerializedName("description")
     public String Description;
@@ -34,6 +36,18 @@ public class DeviceVoiceFile {
         // voiceFile.compressedFile: this is the filename of the downloaded file before decompression
     }
 
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        DeviceVoiceFile other = (DeviceVoiceFile) obj;
+        return Type.equals(other.Type) && Path.equals(other.Path) && Md5Sum.equals(other.Md5Sum) && Platform.equals(other.Platform) && PhonemeType.equals(other.PhonemeType);
+    }
+
     @NonNull
     @Override
     public String toString() {
@@ -44,5 +58,18 @@ public class DeviceVoiceFile {
                 ", PhonemeType='" + PhonemeType + '\'' +
                 ", Md5Sum='" + Md5Sum + '\'' +
                 '}';
+    }
+
+
+    public int hashCode() {
+        // you pick a hard-coded, randomly chosen, non-zero, odd number
+        // ideally different for each class
+        return new HashCodeBuilder(17, 31).
+                append(Type).
+                append(Path).
+                append(Md5Sum).
+                append(Platform).
+                append(PhonemeType).
+                toHashCode();
     }
 }

--- a/app/src/main/java/com/grammatek/simaromur/device/pojo/DeviceVoices.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/pojo/DeviceVoices.java
@@ -4,6 +4,8 @@ import androidx.annotation.NonNull;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -85,6 +87,21 @@ public class DeviceVoices {
         return combinedVoices;
     }
 
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        DeviceVoices other = (DeviceVoices) obj;
+        // compare Voices via constructing List difference
+        List<DeviceVoice> differences  = new ArrayList<>(other.Voices);
+        differences.removeAll(Voices);
+        return differences.isEmpty() && Voices.size() == other.Voices.size();
+    }
+
     @NonNull
     @Override
     public String toString() {
@@ -92,5 +109,13 @@ public class DeviceVoices {
                 "description='" + Description + '\'' +
                 ", voices=[" + Voices.toString() + ']' +
                 '}';
+    }
+
+    public int hashCode() {
+        // you pick a hard-coded, randomly chosen, non-zero, odd number
+        // ideally different for each class
+        return new HashCodeBuilder(17, 29).
+                append(Voices).
+                toHashCode();
     }
 }


### PR DESCRIPTION
- do network connection check before downloading a voice
- make sure, the device voice inside the description for downloaded voices really is unique
- add `equals()` and `hashCode()` methods to `DeviceVoiceXXX` Pojos for uniqueness comparison
- delete voice info from downloaded voice description, there were dangling voice info descriptions inside
- synchronize access to public methods in DownloadVoiceManager
- proper error handling in async download thread by calling appropriate observer callbacks
- don't subscribe multiple times the same kind of observer for changes of voice db
- bugfixes in case network connection comes back and pressing "download"
- don't log a load of progress for "every byte" downloaded, but only each 10% iteration
- make sure to run on UIThread when changing `mProgressBar`