### PR TITLE
Fixes the state "Server Voice description not available !"

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/AppRepository.java
+++ b/app/src/main/java/com/grammatek/simaromur/AppRepository.java
@@ -259,6 +259,15 @@ public class AppRepository {
     }
 
     /**
+     * Triggers an update of the server voice description asynchronously. The update is triggered
+     * immediately.
+     */
+    public void triggerServerVoiceUpdate() {
+        Log.v(LOG_TAG, "triggerServerVoiceUpdate()");
+        mScheduler.schedule(onDeviceVoicesUpdateRunnable, 0, TimeUnit.SECONDS);
+    }
+
+    /**
      * Returns the utterance cache manager
      *
      * @return instance of the utterance cache manager

--- a/app/src/main/java/com/grammatek/simaromur/device/DownloadVoiceManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/DownloadVoiceManager.java
@@ -213,6 +213,7 @@ public class DownloadVoiceManager {
      */
     synchronized
     public void readVoiceDescription(boolean includeServer) {
+        Log.v(LOG_TAG, "readVoiceDescription(" + includeServer + ")");
         final String voiceDescriptionDiskPath = mVoiceDownloadPath + "/voice-info.json";
         final String voiceDescriptionServerCachePath = mVoiceDownloadPath + "/voice-info-server-cache.json";
         try {
@@ -229,6 +230,8 @@ public class DownloadVoiceManager {
                 } else {
                     Log.e(LOG_TAG, "Could not read voice description from server!");
                 }
+            } else if (!includeServer && voicesOnServer == null) {
+                App.getAppRepository().triggerServerVoiceUpdate();
             } else {
                 mVoicesOnServer = voicesOnServer;
             }


### PR DESCRIPTION
If the initial request for fetching the voice description was not successful, the message **Server Voice description not available !** would only disappear either after a restart of the app and a hopefully then successful fetching of the voice info from the server or after the interval of 60 minutes for the next server voice info update had been reached. This commit fixes the problem that downloading the voice *Álfur hratt* doesn't work in the meanwhile.

Add a new trigger method `triggerServerVoiceUpdate()` for downloading the server voice info to the `AppRepository` class. This method initiates async. downlad of the server voice info in the usual way. The call is done locally inside `readVoiceDescription(false)`, i.e for the case that `includeServer` parameter is set to false.

Basically this trigger is an indirect recursion of `readVoiceDescription(false)` to `readVoiceDescription(true)` via an async. scheduler call to circumvent blocking the UI thread.

This fixes #124 