### PR TITLE
Make it possible to update downloadable voices from new release

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/AppRepository.java
+++ b/app/src/main/java/com/grammatek/simaromur/AppRepository.java
@@ -943,11 +943,15 @@ public class AppRepository {
     };
 
     /**
-     * Update DB according to On-Device voices
+     * Update DB according to On-Device voices. This polls regularly the voice list from the
+     * server and updates the DB accordingly. A voice is considered to be "new" if it is not
+     * present in the DB yet or not anymore after deletion.
+     *
      */
     final Runnable onDeviceVoicesUpdateRunnable = new Runnable() {
         @Override
         public void run() {
+            Log.v(LOG_TAG, "onDeviceVoicesUpdateRunnable()");
             // fetch on-device voice lists
             mDVM.readVoiceDescription(true);
 
@@ -955,9 +959,11 @@ public class AppRepository {
             final List<Voice> onDeviceVoices = mDVM.getVoiceDbList();
             for (Voice voice : onDeviceVoices) {
                 // check if voice is already in DB
-                if (mVoiceDao.findVoice(voice.name, voice.internalName, voice.languageCode, voice.languageName, voice.variant) == null) {
+                if (mVoiceDao.findVoice(voice.name, voice.internalName, voice.languageCode, voice.languageName, voice.variant, voice.version) == null) {
                     Log.w(LOG_TAG, "onDeviceVoiceRunnable Add on device voice " + voice.name);
                     mVoiceDao.insertVoices(voice);
+                } else {
+                    Log.w(LOG_TAG, "onDeviceVoicesUpdateRunnable Voice " + voice.name + " already in DB");
                 }
             }
         }

--- a/app/src/main/java/com/grammatek/simaromur/VoiceInfo.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceInfo.java
@@ -307,7 +307,11 @@ public class VoiceInfo extends AppCompatActivity
 
         @Override
         public void hasFinished(boolean success) {
-            runOnUiThread(() -> mSpinner.setVisibility(View.GONE));
+            runOnUiThread(() -> {
+                mSpinner.setVisibility(View.GONE);
+                App.getAppRepository().triggerServerVoiceUpdate();
+                finish();
+            });
         }
         @Override
         public void updateProgress(int progress) {

--- a/app/src/main/java/com/grammatek/simaromur/db/VoiceDao.java
+++ b/app/src/main/java/com/grammatek/simaromur/db/VoiceDao.java
@@ -40,9 +40,10 @@ public interface VoiceDao {
     List<Voice> findVoiceWithName(String name);
 
     @Query("SELECT * FROM voice_table WHERE name IS :name AND internal_name IS :internalName" +
-            " AND language_code IS :languageCode AND language_name IS :languageName AND variant IS :variant")
+            " AND language_code IS :languageCode AND language_name IS :languageName" +
+            " AND variant IS :variant AND version IS :version")
     Voice findVoice(String name, String internalName, String languageCode, String languageName,
-                    String variant);
+                    String variant, String version);
 
     @Query("SELECT * FROM voice_table WHERE type LIKE 'network' ")
     List<Voice> findNetworkVoices();


### PR DESCRIPTION
- if the old voice is deleted, the meta data is wiped from db and disk
- a new release info fetch from github is initiated
- the hard coded value DownloadVoiceManager::sReleaseName is used for fetching the voice release meta data
- the voice manager shows the updated entry from the voice db and the user can download the release just normally as before

