### PR TITLE
Prepare release 1.3.0

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/AppRepository.java
+++ b/app/src/main/java/com/grammatek/simaromur/AppRepository.java
@@ -117,6 +117,7 @@ public class AppRepository {
         if (isCurrentVoice(voice)) return false;
 
         mDVM.deleteVoice(voice, deleteVoiceObserver, mVoiceDao);
+        mTTSEngineController.UnloadEngine();
         return true;
     }
 
@@ -255,6 +256,7 @@ public class AppRepository {
      * @throws InterruptedException if the thread is interrupted
      */
     public TTSProcessingResult dequeueTTSProcessingResult() throws InterruptedException {
+        Log.v(LOG_TAG, "dequeueTTSProcessingResult()");
         return mTTSProcessingResultQueue.take();
     }
 

--- a/app/src/main/java/com/grammatek/simaromur/InfoViewer.java
+++ b/app/src/main/java/com/grammatek/simaromur/InfoViewer.java
@@ -217,31 +217,41 @@ public class InfoViewer extends AppCompatActivity {
         private View getCacheCardView(LayoutInflater inflater, ViewGroup parent) {
             UtteranceCacheManager mCacheManager = App.getAppRepository().getUtteranceCache();
 
-            View cView1 = inflater.inflate(R.layout.about_list_item_cache, parent, false);
-            TextView title = cView1.findViewById(R.id.info_title);
+            View cardView = inflater.inflate(R.layout.about_list_item_cache, parent, false);
+            TextView title = cardView.findViewById(R.id.info_title);
             title.setText(R.string.cache);
 
-            ImageView button = cView1.findViewById(R.id.trash_bin);
+            ImageView button = cardView.findViewById(R.id.trash_bin);
             button.setOnClickListener(it -> {
                 mCacheManager.clearCache();
                 if (context != null) {
+                    updateVoiceCacheProgressBar(cardView, 0);
                     Toast.makeText(context, R.string.cache_cleared, Toast.LENGTH_LONG).show();
                 }
             });
 
             double cacheUsed = mCacheManager.getAudioFileSize() / (1024.0 * 1024.0);
             double cacheMax = mCacheManager.getCacheSizeHighWatermark() / (1024.0 * 1024.0);
-            TextView text = cView1.findViewById(R.id.info_text);
+            TextView text = cardView.findViewById(R.id.info_text);
             text.setText(context.getString(R.string.cache_size_mb, (int) cacheMax));
 
             int progress_percentage = (int) ((cacheUsed / cacheMax) * 100);
-            TextView progress = cView1.findViewById(R.id.progress_bar_percentage);
-            progress.setText(context.getString(R.string.cache_progress_percent, progress_percentage));
+            updateVoiceCacheProgressBar(cardView, progress_percentage);
 
-            ProgressBar progressBar = cView1.findViewById(R.id.cache_storage_bar);
-            progressBar.setProgress(progress_percentage);
+            return cardView;
+        }
 
-            return cView1;
+        /**
+         * Updates the progress bar of the voice cache card
+         *
+         * @param view  the view of the card
+         * @param x     the progress percentage
+         */
+        private void updateVoiceCacheProgressBar(View view, int x) {
+            TextView progress = view.findViewById(R.id.progress_bar_percentage);
+            progress.setText(context.getString(R.string.cache_progress_percent, x));
+            ProgressBar progressBar = view.findViewById(R.id.cache_storage_bar);
+            progressBar.setProgress(x);
         }
 
         private View getTitleView(LayoutInflater inflater, ViewGroup parent, int position) {

--- a/app/src/main/java/com/grammatek/simaromur/device/DownloadVoiceManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/DownloadVoiceManager.java
@@ -51,8 +51,7 @@ public class DownloadVoiceManager {
     private final String mVoiceDescriptionServerCachePath;
     // TODO: this is hardcoded for now, but should be dynamic in the future, when we implement
     //       the update mechanism
-    private static final String sReleaseName = "0.2 test release";
-    //private static final String sReleaseName = "0.1 release";
+    private static final String sReleaseName = "0.2 release";
     private static final String sVoiceInternalName = "Alfur_flite";
     // All device voices available on disk
     private DeviceVoices mVoicesOnDisk;

--- a/app/src/main/java/com/grammatek/simaromur/device/TTSEngineController.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/TTSEngineController.java
@@ -111,6 +111,10 @@ public class TTSEngineController {
         }
     }
 
+    /**
+     * Unload the current TTS engine and free all resources.
+     */
+    synchronized
     public void UnloadEngine() {
         Log.v(LOG_TAG, "UnloadEngine()");
         if (mEngine != null) {
@@ -122,6 +126,7 @@ public class TTSEngineController {
     /**
      * Start to speak given text with given voice.
      */
+    synchronized
     public SpeakTask StartSpeak(CacheItem item, float speed, float pitch, int sampleRate,
                            TTSAudioControl.AudioFinishedObserver observer, TTSRequest ttsRequest) {
         if (mEngine == null || mCurrentVoice == null) {
@@ -144,6 +149,7 @@ public class TTSEngineController {
      * Start to speak given text with given voice and use given callback for applying the synthesized
      * output.
      */
+    synchronized
     public void StartSpeak(TTSObserver observer, TTSRequest ttsRequest) {
         if (mEngine == null || mCurrentVoice == null) {
             String errorMsg = "No TTS engine loaded !";
@@ -163,6 +169,7 @@ public class TTSEngineController {
     /**
      * Stop speaking. Ignored in case currently no speak execution is done.
      */
+    synchronized
     public void StopSpeak(TTSEngineController.SpeakTask speakTask) {
         mTTSAudioControl16khz.stop();
         mTTSAudioControl22khz.stop();

--- a/app/src/main/java/com/grammatek/simaromur/device/TTSEngineController.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/TTSEngineController.java
@@ -111,6 +111,14 @@ public class TTSEngineController {
         }
     }
 
+    public void UnloadEngine() {
+        Log.v(LOG_TAG, "UnloadEngine()");
+        if (mEngine != null) {
+            mCurrentVoice = null;
+            mEngine = null;
+        }
+    }
+
     /**
      * Start to speak given text with given voice.
      */

--- a/app/src/main/java/com/grammatek/simaromur/frontend/UnicodeMaps.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/UnicodeMaps.java
@@ -45,7 +45,8 @@ public class UnicodeMaps {
         deleteCharsMap.put('\u200e', ""); // left-to-right mark
         // deleteCharsMap.put('\u2019', ""); // right single quotation mark -> why delete? moved to otherSubstMap
         deleteCharsMap.put('\ufeff', ""); // zero width no-break space
-        deleteCharsMap.put('\ue910', "");
+        deleteCharsMap.put('\ue910', ""); // private use area
+        deleteCharsMap.put('\ue951', ""); // private use area (e.g. clock symbol in Visir.is before date & time)
     }
 
     public static Map<Character, String> insertSpaceMap = new HashMap<>();


### PR DESCRIPTION
This MR prepares relase 1.3.0. It adds a few minor changes:

- TTSEngineController: unload current on-device voice if a downloadable voice is deleted and add a few missing synchronized declarations 
- update the cache progress bar UI in the info screen when deleting the voice cache
- use voice release 0.2 of Símarómur Voices Github repo
