### PR TITLE
WIP: Feat/experimental vits

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -267,11 +267,8 @@ dependencies {
     // Add PyTorch dependencies
     implementation 'org.pytorch:pytorch_android_lite:1.12.2'
 
-    // Add Tensorflow lite dependencies, not needed, therefore disabling it because the release
-    // binary gets too big !
-    //implementation 'org.tensorflow:tensorflow-lite:2.6.0'
-    //implementation 'org.tensorflow:tensorflow-lite-support:0.3.0'
-    //implementation 'org.tensorflow:tensorflow-lite-select-tf-ops:2.6.0'
+    // onnx runtime, full package
+    implementation 'com.microsoft.onnxruntime:onnxruntime-android:latest.release'
 
     implementation "androidx.datastore:datastore:1.0.0"
 

--- a/app/src/main/java/com/grammatek/simaromur/AppRepository.java
+++ b/app/src/main/java/com/grammatek/simaromur/AppRepository.java
@@ -98,12 +98,16 @@ public class AppRepository {
      * @return    value for key or empty string if not found
      */
     public String getAssetConfigValueFor(String key) {
+        String rv = "";
         try {
-            return FileUtils.getAssetConfigProperty(App.getContext().getAssets(), key);
+            String value = FileUtils.getAssetConfigProperty(App.getContext().getAssets(), key);
+            if (value != null) {
+                rv = value;
+            }
         } catch (IOException e) {
             e.printStackTrace();
-            return "";
         }
+        return rv;
     }
 
     /**

--- a/app/src/main/java/com/grammatek/simaromur/AppRepository.java
+++ b/app/src/main/java/com/grammatek/simaromur/AppRepository.java
@@ -549,7 +549,9 @@ public class AppRepository {
         List<Voice> voices = mVoiceDao.getAnyVoices();
         for (final Voice voice : voices) {
             if (voice.name.equals(voiceName)) {
-                if (voice.type.equals(Voice.TYPE_TORCH) || voice.type.equals(Voice.TYPE_FLITE)) {
+                if (voice.type.equals(Voice.TYPE_TORCH)
+                        || voice.type.equals(Voice.TYPE_FLITE)
+                        || voice.type.equals(Voice.TYPE_ONNX)) {
                     try {
                         mTTSEngineController.LoadEngine(voice);
                     } catch (IOException e) {

--- a/app/src/main/java/com/grammatek/simaromur/TTSService.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSService.java
@@ -248,7 +248,7 @@ public class TTSService extends TextToSpeechService {
     private void handleProcessingResult(SynthesisCallback callback, CacheItem item, TTSRequest ttsRequest, com.grammatek.simaromur.db.Voice voice) {
         Log.v(LOG_TAG, "handleProcessingResult for (" + item.getUuid() + ")");
         try {
-            // get the current time for caclulating the amount of time that we have waited
+            // get the current time for calculating the amount of time that we have waited
             long startTime = System.currentTimeMillis();
             boolean isCached = item.containsVoiceAudioEntries(UtteranceCacheManager.buildVoiceKey(voice.internalName, voice.version));
             // here we wait for the response of the speak request. The result is sent via the queue
@@ -380,6 +380,10 @@ public class TTSService extends TextToSpeechService {
      */
     private static void setSpeechMarksToBeginning(SynthesisCallback callback) {
         Log.v(LOG_TAG, "setSpeechMarksToBeginning()");
+        if (! callback.hasStarted()) {
+            Log.w(LOG_TAG, "setSpeechMarksToBeginning(): callback not started yet ?!");
+            return;
+        }
         callback.rangeStart(0, 0, 1);
         byte[] silenceData = new byte[callback.getMaxBufferSize()];
         callback.audioAvailable(silenceData, 0, silenceData.length);
@@ -501,13 +505,13 @@ public class TTSService extends TextToSpeechService {
             Set<String> features = new HashSet<>();
 
             if (voice.type.equals(com.grammatek.simaromur.db.Voice.TYPE_NETWORK)) {
-                latency = Voice.LATENCY_VERY_HIGH;
+                    latency = Voice.LATENCY_VERY_HIGH;
                 quality = Voice.QUALITY_HIGH;
-                features.add(TextToSpeech.Engine.KEY_FEATURE_NETWORK_RETRIES_COUNT);
-                needsNetwork = true;
+                    features.add(TextToSpeech.Engine.KEY_FEATURE_NETWORK_RETRIES_COUNT);
+                    needsNetwork = true;
             } else if (voice.type.equals(com.grammatek.simaromur.db.Voice.TYPE_TORCH)) {
                 quality = Voice.QUALITY_VERY_HIGH;
-                latency = Voice.LATENCY_VERY_HIGH;
+                    latency = Voice.LATENCY_VERY_HIGH;
             }
             if (voice.needsDownload()) {
                 features.add(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED);

--- a/app/src/main/java/com/grammatek/simaromur/TTSService.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSService.java
@@ -46,6 +46,10 @@ public class TTSService extends TextToSpeechService {
         // This calls onIsLanguageAvailable() and must run after Initialization
         super.onCreate();
         mRepository.streamNetworkVoices("");
+        applyCachePolicy();
+    }
+
+    private void applyCachePolicy() {
         String val = mRepository.getAssetConfigValueFor("rm_cache_item_after_playing");
         if (val.equals("true")) {
             mRmCacheItemAfterPlaying = true;
@@ -214,6 +218,11 @@ public class TTSService extends TextToSpeechService {
                 break;
             case com.grammatek.simaromur.db.Voice.TYPE_TORCH:
                 startSynthesisCallback(callback, AudioManager.SAMPLE_RATE_TORCH, false);
+                setSpeechMarksToBeginning(callback);
+                mRepository.startDeviceTTS(voice, item, ttsRequest, speechrate / 100.0f, pitch / 100.0f);
+                break;
+            case com.grammatek.simaromur.db.Voice.TYPE_ONNX:
+                startSynthesisCallback(callback, AudioManager.SAMPLE_RATE_ONNX, false);
                 setSpeechMarksToBeginning(callback);
                 mRepository.startDeviceTTS(voice, item, ttsRequest, speechrate / 100.0f, pitch / 100.0f);
                 break;

--- a/app/src/main/java/com/grammatek/simaromur/VoiceInfo.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceInfo.java
@@ -373,9 +373,15 @@ public class VoiceInfo extends AppCompatActivity
             toggleSpeakButton();
         }
 
-        // execute frontend, generate new TTS request
+        // execute frontend
         CacheItem item = appRepo.getUtteranceCache().addUtterance(text);
         item = appRepo.executeFrontendAndSaveIntoCache(text, item, mVoice);
+        if ((item.getUtterance().getPhonemesCount() == 0) ||
+                item.getUtterance().getPhonemesList().get(0).getSymbols().isEmpty()) {
+            Log.w(LOG_TAG, "onPlayClicked: No phonemes to speak");
+            return;
+        }
+        // create TTS request
         TTSRequest ttsRequest = new TTSRequest(item.getUuid());
         appRepo.setCurrentTTSRequest(ttsRequest);
 

--- a/app/src/main/java/com/grammatek/simaromur/VoiceViewModel.java
+++ b/app/src/main/java/com/grammatek/simaromur/VoiceViewModel.java
@@ -70,6 +70,7 @@ public class VoiceViewModel extends AndroidViewModel {
                 break;
             case Voice.TYPE_TORCH:
             case Voice.TYPE_FLITE:  // FALLTHROUGH
+            case Voice.TYPE_ONNX:  // FALLTHROUGH
                 mDevSpeakTask = mRepository.startDeviceSpeak(voice, item, speed, pitch, finishedObserver);
                 break;
             default:

--- a/app/src/main/java/com/grammatek/simaromur/audio/AudioManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/audio/AudioManager.java
@@ -20,7 +20,8 @@ public class AudioManager {
     public static final int SAMPLE_RATE_WAV = 16000;
     public static final int SAMPLE_RATE_MP3 = 22050;
     public static final int SAMPLE_RATE_TORCH = 22050;
-    public static final int SAMPLE_RATE_ONNX = 22050;
+    public static final int SAMPLE_RATE_ONNX = 16000;
+    //public static final int SAMPLE_RATE_ONNX = 22050;
     public static final int N_CHANNELS = 1;
 
     /**
@@ -166,10 +167,13 @@ public class AudioManager {
      * @param pcmFloats pcm floats [-1.0 .. 1.0]
      *
      * @return byte array PCM big endian
+     *
+     * @note: no normalization is done, the floats need to be in the range [-1.0 .. 1.0] and the
+     *        max. dynamic range is not applied
      */
     static public byte[] pcmFloatTo16BitPCM(float[] pcmFloats) {
         final int bitDepth = 16;
-        Log.v(LOG_TAG, "pcmFloatTo16BitPCM: Converting " + pcmFloats.length + " float samples to " + bitDepth + " bit wav ...");
+        Log.d(LOG_TAG, "pcmFloatTo16BitPCM: Converting " + pcmFloats.length + " float samples to " + bitDepth + " bit wav ...");
         final int ByteRate = bitDepth / 8;
         final int MULT_FACTOR = (int) Math.pow(2, bitDepth-1);
         int nClipped = 0;
@@ -202,13 +206,12 @@ public class AudioManager {
         if (nClipped > 0) {
             Log.w(LOG_TAG, "pcmFloatTo16BitPCM: " + nClipped + " clipped samples detected");
         }
-        Log.w(LOG_TAG, "pcmFloatTo16BitPCM: values min/max: " + min + "/" + max);
 
         buffer.rewind();
         buffer.order(ByteOrder.BIG_ENDIAN);
         byte[] outBuf = new byte[pcmFloats.length * ByteRate];
         buffer.get(outBuf);
-        Log.v(LOG_TAG, "Done.");
+        Log.d(LOG_TAG, "pcmFloatTo16BitPCM: values min/max: " + min + "/" + max);
         return outBuf;
     }
 

--- a/app/src/main/java/com/grammatek/simaromur/audio/AudioManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/audio/AudioManager.java
@@ -20,6 +20,7 @@ public class AudioManager {
     public static final int SAMPLE_RATE_WAV = 16000;
     public static final int SAMPLE_RATE_MP3 = 22050;
     public static final int SAMPLE_RATE_TORCH = 22050;
+    public static final int SAMPLE_RATE_ONNX = 22050;
     public static final int N_CHANNELS = 1;
 
     /**

--- a/app/src/main/java/com/grammatek/simaromur/db/Voice.java
+++ b/app/src/main/java/com/grammatek/simaromur/db/Voice.java
@@ -32,10 +32,10 @@ public class Voice {
     public final static String TYPE_NETWORK_OLD = "tiro";
     public final static String TYPE_NETWORK = "network";
     public final static String TYPE_TORCH = "torchscript";
-    public final static String TYPE_TFLOW = "tensorflow";
     public final static String TYPE_FLITE = "flite";
+    public final static String TYPE_ONNX = "onnx";
 
-    public static final List<String> Types = Arrays.asList(TYPE_NETWORK, TYPE_NETWORK_OLD, TYPE_FLITE, TYPE_TORCH, TYPE_TFLOW);
+    public static final List<String> Types = Arrays.asList(TYPE_NETWORK, TYPE_NETWORK_OLD, TYPE_FLITE, TYPE_TORCH, TYPE_ONNX);
     static final String SEP = "-";
 
     @PrimaryKey(autoGenerate = true)

--- a/app/src/main/java/com/grammatek/simaromur/device/DownloadVoiceManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/DownloadVoiceManager.java
@@ -370,7 +370,11 @@ public class DownloadVoiceManager {
      */
     synchronized
     public DeviceVoice getInfoForVoice(String internalName) throws IOException {
-        for (DeviceVoice voice:getVoiceList().Voices) {
+        List<DeviceVoice> voices = getVoiceList().Voices;
+        if (voices == null) {
+            throw new IOException("No voices available");
+        }
+        for (DeviceVoice voice:voices) {
             if (voice.InternalName.equals(internalName)) {
                 return voice;
             }

--- a/app/src/main/java/com/grammatek/simaromur/device/SymbolsLvLIs.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/SymbolsLvLIs.java
@@ -47,8 +47,11 @@ public class SymbolsLvLIs {
     private final static String SymbolsSpecial = SymbolShortPause + " " + SymbolSpokenNoise + " " +
             SymbolSilence;
 
-    // tags
+
+    // tags + stresses
     public final static String TagPause = "<sil>";
+    public final static String PrimaryStress = "ˈ";
+    public final static String SecondaryStress = "ˌ";
 
     // IPA symbols as HashMap
     private static final HashMap<String, Integer> IPASymbolMap;

--- a/app/src/main/java/com/grammatek/simaromur/device/TTSEngineController.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/TTSEngineController.java
@@ -90,6 +90,24 @@ public class TTSEngineController {
                     Log.v(LOG_TAG, "LoadEngine: (cached)");
                 }
                 break;
+            case Voice.TYPE_ONNX:
+                // use the asset voice manager to get the info for the voices, this assumes that
+                // the onnx model is only available inside the assets folder
+                devVoice = mAVM.getInfoForVoice(voice.name);
+                if (mEngine == null || devVoice != mCurrentVoice) {
+                    Log.v(LOG_TAG, "LoadEngine: " + devVoice.Type);
+                    try {
+                        mEngine = new TTSEngineOnnx(App.getContext().getAssets(), devVoice);
+                        mCurrentVoice = devVoice;
+                    } catch (IllegalArgumentException e) {
+                        Log.e(LOG_TAG, "LoadEngine: " + e.getMessage());
+                        throw e;
+                    }
+                }
+                else {
+                    Log.v(LOG_TAG, "LoadEngine: (cached)");
+                }
+                break;
             case Voice.TYPE_FLITE:
                 devVoice = mDVM.getInfoForVoice(voice.internalName);
                 if (mEngine == null || devVoice != mCurrentVoice) {

--- a/app/src/main/java/com/grammatek/simaromur/device/TTSEngineOnnx.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/TTSEngineOnnx.java
@@ -1,0 +1,245 @@
+package com.grammatek.simaromur.device;
+
+import android.content.res.AssetManager;
+import android.util.Log;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.grammatek.simaromur.App;
+import com.grammatek.simaromur.audio.AudioManager;
+import com.grammatek.simaromur.device.pojo.DeviceVoice;
+import com.grammatek.simaromur.device.pojo.DeviceVoiceFile;
+import com.grammatek.simaromur.device.pojo.VitsConfig;
+import com.grammatek.simaromur.frontend.Pronunciation;
+import com.grammatek.simaromur.frontend.PronunciationVits;
+import com.grammatek.simaromur.utils.FileUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OrtEnvironment;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtProvider;
+import ai.onnxruntime.OrtSession;
+import ai.onnxruntime.OrtSession.Result;
+import ai.onnxruntime.OrtSession.SessionOptions;
+import ai.onnxruntime.OrtSession.SessionOptions.OptLevel;
+
+public class TTSEngineOnnx  implements TTSEngine {
+    private final static String LOG_TAG = "Simaromur_" + TTSEngineOnnx.class.getSimpleName();
+    private final static int SAMPLE_RATE = 22050;
+    private static DeviceVoice mVoice = null;
+
+    private OrtEnvironment mOrtEnv;
+    private OrtSession.SessionOptions mOrtOpts;
+    private OrtSession mOrtSession;
+
+    private final Pronunciation mPronunciation;
+    private final PronunciationVits mPronunciationVits;
+    private VitsConfig mModelConfig;
+
+    public TTSEngineOnnx(AssetManager asm, DeviceVoice voice) {
+        assert (voice.Type.equals("onnx"));
+
+        String modelPath = null;
+        String configPath = null;
+        for (DeviceVoiceFile voiceFile : voice.Files) {
+            switch (voiceFile.Type) {
+                case "vits":
+                    modelPath = "voices/" + voiceFile.Path;
+                    break;
+                case "json":
+                    configPath = "voices/" + voiceFile.Path;
+                    break;
+                default:
+                    Log.e(LOG_TAG, "Unknown model type " + voiceFile.Type);
+                    assert (false);
+                    break;
+            }
+        }
+
+        if (modelPath == null) {
+            throw new RuntimeException("Voice " + voice.Name + " doesn't specify all required models");
+        }
+        if (configPath == null) {
+            throw new RuntimeException("Voice " + voice.Name + ": no config file found");
+        }
+
+        // In case of a new voice: unload all existing models
+        if (mVoice != voice) {
+            readVitsModelConfig(asm, configPath);
+            createVitsModel(asm, modelPath, configPath);
+        }
+        mPronunciation = new Pronunciation(App.getContext());
+        mPronunciationVits = new PronunciationVits(mPronunciation);
+
+        Log.v(LOG_TAG, "Onnx model loaded from assets/" + modelPath);
+        mVoice = voice;
+    }
+
+    /**
+     * Return a boolean, if NNAPI is supported on the device.
+     *
+     * @return  Boolean, true if NNAPI is supported, false otherwise.
+     */
+    private boolean isNnapiSupported() {
+        return android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O_MR1;
+    }
+
+    private void createVitsModel(AssetManager asm, String modelPath, String configPath) {
+        mOrtEnv = OrtEnvironment.getEnvironment();
+        mOrtOpts = new SessionOptions();
+
+        try {
+            if (false && isNnapiSupported()) {
+                // TODO: Unfortunately, NNAPI is not working optimally yet in combination with our
+                //       VITS model according to the ORT checker, let's wait for a newer version of
+                //       onnxruntime
+                Log.i(LOG_TAG, "NNAPI is supported, using NNAPI for inference");
+                mOrtOpts.addConfigEntry("session.set_execution_providers", OrtProvider.NNAPI.getName());
+                // NNAPI should not fall back to CPU
+                mOrtOpts.addConfigEntry("NNAPIFlags", "1");
+            } else {
+                Log.i(LOG_TAG, "NNAPI is not supported, using CPU for inference");
+                mOrtOpts.addConfigEntry("session.set_execution_providers", OrtProvider.CPU.getName());
+            }
+            mOrtOpts.setOptimizationLevel(OptLevel.ALL_OPT);
+        } catch (OrtException e) {
+            throw new RuntimeException(e);
+        }
+        try {
+            byte[] modelBytes = FileUtils.readFileFromAssets(asm, modelPath);
+            mOrtSession = mOrtEnv.createSession(modelBytes, mOrtOpts);
+        } catch (IOException | OrtException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void readVitsModelConfig(AssetManager asm, String configPath) {
+        // read configuration from assets
+        try {
+            byte[] buf = FileUtils.readFileFromAssets(asm, configPath);
+            try {
+                String jsonString = new String(buf, StandardCharsets.UTF_8);
+                Gson gson = new Gson();
+                mModelConfig = gson.fromJson(jsonString, VitsConfig.class);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } catch (JsonSyntaxException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public byte[] SpeakToPCM(String ipas) {
+        Instant startTime = Instant.now();
+
+        // squeeze out all spaces and replace §sp to space again
+        Log.v(LOG_TAG, "Vits phonemes: " + ipas);
+        // Python:
+        // phoneme_ids_array = np.expand_dims(np.array(phoneme_ids, dtype=np.int64), 0)
+        //        phoneme_ids_lengths = np.array([phoneme_ids_array.shape[1]], dtype=np.int64)
+        //        scales = np.array(
+        //            [noise_scale, length_scale, noise_w],
+        //            dtype=np.float32,
+        //        )
+        // "noise_scale": 0.667,
+        // "length_scale": 1,
+        // "noise_w": 0.8
+
+        // append each character in variable ipas with a PAD_SYMBOL, independent of space, dot, comma, etc.
+        ipas = ipas.replaceAll("(.)", "$1" + '_');
+        // prepend with BOS and append with EOS
+        ipas = "^" + ipas + "$";
+
+        VitsPhoneConverter phoneConverter = new VitsPhoneConverter(mModelConfig.phonemeIdMap);
+        long[] ipa2VecInput = phoneConverter.convertToPhonemeIds(ipas);
+        long[][] phoneIdsArray = new long[1][ipa2VecInput.length];
+        System.arraycopy(ipa2VecInput, 0, phoneIdsArray[0], 0, ipa2VecInput.length);
+        long[] phoneIdsLengths = new long[] {phoneIdsArray[0].length};
+        // these are fixed now, but should be used from the voice config file
+        float noiseScale = mModelConfig.inference.noiseScale;
+        float lengthScale = mModelConfig.inference.lengthScale;
+        float noiseW = mModelConfig.inference.noiseW;
+        float[] scales = new float[] {noiseScale, lengthScale, noiseW};
+        // textTensor
+        try {
+            Map<String, OnnxTensor> inputMap = new HashMap<String, OnnxTensor>();
+            // this call uses inflection for the input tensor
+            inputMap.put("input", OnnxTensor.createTensor(mOrtEnv, phoneIdsArray));
+            inputMap.put("input_lengths", OnnxTensor.createTensor(mOrtEnv, phoneIdsLengths));
+            inputMap.put("scales", OnnxTensor.createTensor(mOrtEnv, scales));
+            // in case we have a speaker id, we need to add an int64 array with the speaker ids like that:
+            // inputMap.put("sid", OnnxTensor.createTensor(mOrtEnv, speakerIds));
+            Result output = mOrtSession.run(inputMap);
+
+            // output 0: array of longs
+            Object outputTensor = output.get(0).getValue();
+            if (outputTensor instanceof float[][][][]) {
+                float[][][][] tensor4D = (float[][][][]) outputTensor;
+                if (tensor4D.length == 1 && tensor4D[0].length == 1) {
+                    float[] samples = tensor4D[0][0][0];
+                    byte[] bytes = AudioManager.pcmFloatTo16BitPCMWithDither(samples, 1.0f, true);
+                    Instant stopTime = Instant.now();
+
+                    final long timeElapsed = Duration.between(startTime, stopTime).toMillis();
+                    Log.i(LOG_TAG, "Voice generation ran for " + timeElapsed / 1000.0F + " secs, " +
+                            samples.length * 1000.0F / timeElapsed / GetNativeSampleRate() + " x real-time");
+                    return bytes;
+                }
+            } else {
+                Log.e(LOG_TAG, "Unexpected output tensor type: " + outputTensor.getClass().getName());
+            }
+        } catch (OrtException e) {
+            throw new RuntimeException(e);
+        }
+        return new byte[0];
+    }
+
+    @Override
+    public int GetNativeSampleRate() {
+        return SAMPLE_RATE;
+    }
+
+    public static class VitsPhoneConverter {
+        private Map<String, int[]> phonemeIdMap;
+
+        public VitsPhoneConverter(Map<String, int[]> phonemeIdMap) {
+            this.phonemeIdMap = phonemeIdMap;
+        }
+
+        public long[] convertToPhonemeIds(String ipaString) {
+            List<Long> phonemeIdList = new ArrayList<>();
+
+            for (int i = 0; i < ipaString.length(); i++) {
+                String symbol = String.valueOf(ipaString.charAt(i));
+                int[] idArray = phonemeIdMap.get(symbol);
+
+                if (idArray != null && idArray.length > 0) {
+                    phonemeIdList.add((long) idArray[0]);
+                } else {
+                    // Log a warning with the symbol and its position
+                    Log.w(LOG_TAG+"::VitsPhoneConverter", "Unknown symbol '" + symbol + "' at position " + i);
+                    // Ignore the unknown symbol
+                }
+            }
+
+            // Convert the List<Long> to long[]
+            long[] phonemeIds = new long[phonemeIdList.size()];
+            for (int i = 0; i < phonemeIdList.size(); i++) {
+                phonemeIds[i] = phonemeIdList.get(i);
+            }
+
+            return phonemeIds;
+        }
+    }
+
+}

--- a/app/src/main/java/com/grammatek/simaromur/device/pojo/VitsConfig.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/pojo/VitsConfig.java
@@ -19,7 +19,10 @@ public class VitsConfig {
     public Map<String, Object> phonemeMap;
 
     @SerializedName("phoneme_id_map")
-    public Map<String, int[]> phonemeIdMap;
+    public Map<String, Integer> phonemeIdMap;
+
+    @SerializedName("phoneme_type")
+    public String phonemeType;
 
     @SerializedName("num_symbols")
     public int numSymbols;
@@ -40,6 +43,7 @@ public class VitsConfig {
                 ", phonemeMap=" + phonemeMap +
                 ", phonemeIdMap=" + phonemeIdMap +
                 ", numSymbols=" + numSymbols +
+                ", phonemeType=" + phonemeType +
                 ", numSpeakers=" + numSpeakers +
                 ", speakerIdMap=" + speakerIdMap +
                 '}';

--- a/app/src/main/java/com/grammatek/simaromur/device/pojo/VitsConfig.java
+++ b/app/src/main/java/com/grammatek/simaromur/device/pojo/VitsConfig.java
@@ -1,0 +1,94 @@
+package com.grammatek.simaromur.device.pojo;
+
+import androidx.annotation.NonNull;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.Map;
+
+public class VitsConfig {
+    @SerializedName("audio")
+    public Audio audio;
+
+    @SerializedName("espeak")
+    public Espeak espeak;
+
+    @SerializedName("inference")
+    public Inference inference;
+
+    @SerializedName("phoneme_map")
+    public Map<String, Object> phonemeMap;
+
+    @SerializedName("phoneme_id_map")
+    public Map<String, int[]> phonemeIdMap;
+
+    @SerializedName("num_symbols")
+    public int numSymbols;
+
+    @SerializedName("num_speakers")
+    public int numSpeakers;
+
+    @SerializedName("speaker_id_map")
+    public Map<String, Object> speakerIdMap;
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "Configuration{" +
+                "audio=" + audio +
+                ", espeak=" + espeak +
+                ", inference=" + inference +
+                ", phonemeMap=" + phonemeMap +
+                ", phonemeIdMap=" + phonemeIdMap +
+                ", numSymbols=" + numSymbols +
+                ", numSpeakers=" + numSpeakers +
+                ", speakerIdMap=" + speakerIdMap +
+                '}';
+    }
+
+    public static class Audio {
+        @SerializedName("sample_rate")
+        public int sampleRate;
+
+        @NonNull
+        @Override
+        public String toString() {
+            return "Audio{" +
+                    "sampleRate=" + sampleRate +
+                    '}';
+        }
+    }
+
+    public static class Espeak {
+        @SerializedName("voice")
+        public String voice;
+
+        @NonNull
+        @Override
+        public String toString() {
+            return "Espeak{" +
+                    "voice='" + voice + '\'' +
+                    '}';
+        }
+    }
+
+    public static class Inference {
+        @SerializedName("noise_scale")
+        public float noiseScale;
+
+        @SerializedName("length_scale")
+        public float lengthScale;
+
+        @SerializedName("noise_w")
+        public float noiseW;
+
+        @NonNull
+        @Override
+        public String toString() {
+            return "Inference{" +
+                    "noiseScale=" + noiseScale +
+                    ", lengthScale=" + lengthScale +
+                    ", noiseW=" + noiseW +
+                    '}';
+        }
+    }
+}

--- a/app/src/main/java/com/grammatek/simaromur/frontend/CardinalMillionTuples.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/CardinalMillionTuples.java
@@ -14,10 +14,6 @@ public class CardinalMillionTuples {
         if (!TUPLES.isEmpty())
             return TUPLES;
 
-        TUPLES.add(new CategoryTuple(NumberPatterns.TNS_PTRN + "10" + NumberPatterns.THSNDS_AND_PTRN_CARDINAL + NumberPatterns.DEC_PTRN_ORDINAL,
-                NormalizationDictionaries.MATCH_ANY, NumberHelper.TEN_THOUSANDS, "tíu þúsund og"));
-        TUPLES.add(new CategoryTuple(NumberPatterns.TNS_PTRN + "10" + NumberPatterns.THSNDS_AND_PTRN_CARDINAL,
-                NormalizationDictionaries.MATCH_ANY, NumberHelper.TEN_THOUSANDS, "tíu þúsund og"));
         TUPLES.add(new CategoryTuple(NumberPatterns.TNS_PTRN + "10" + NumberPatterns.THSNDS_PTRN_AFTER + NumberPatterns.DEC_PTRN_ORDINAL,
                 NormalizationDictionaries.MATCH_ANY, NumberHelper.TEN_THOUSANDS, " tíu þúsund"));
         TUPLES.add(new CategoryTuple(NumberPatterns.HNDRDS_PTRN + "100" + NumberPatterns.THSNDS_AND_PTRN_CARDINAL + NumberPatterns.DEC_PTRN,

--- a/app/src/main/java/com/grammatek/simaromur/frontend/FrontendManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/FrontendManager.java
@@ -52,6 +52,17 @@ public class FrontendManager {
         return transcribe(normalized, IGNORE_TYPE, IGNORE_VERSION);
     }
 
+    /**
+     * Transcribe text to IPA symbols. Punctuation is kept as is, which conforms to the kind of
+     * IPA dialect encoded into the VITS model.
+     *
+     * @param text          The text to be transcribed to IPA phonemes
+     * @param voiceType     The voice type, e.g. "onnx"
+     * @param voiceVersion  The voice version, e.g. "1.0"
+     *
+     * @return  The transcription as IPA phonemes separated by spaces or empty string if no
+     *          relevant phonemes were found.
+     */
     public String transcribe(String text, String voiceType, String voiceVersion) {
         Log.v(LOG_TAG, "transcribe() called");
 

--- a/app/src/main/java/com/grammatek/simaromur/frontend/FrontendManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/FrontendManager.java
@@ -19,12 +19,14 @@ public class FrontendManager {
     private final static String IGNORE_TYPE = "ignoreType";
     private final static String IGNORE_VERSION = "ignoreVersion";
 
-    private NormalizationManager mNormalizationManager;
-    private Pronunciation mPronunciation;
+    private NormalizationManager mNormalizationManager = null;
+    private Pronunciation mPronunciation = null;
+    private PronunciationVits mPronunciationVits = null;
 
     public FrontendManager(Context context) {
-        initializeNormalizationManager(context);
-        initializePronunciation(context);
+        mNormalizationManager = new NormalizationManager(context);
+        mPronunciation = new Pronunciation(context);
+        mPronunciationVits = new PronunciationVits(mPronunciation);
     }
 
     /**
@@ -53,7 +55,12 @@ public class FrontendManager {
     public String transcribe(String text, String voiceType, String voiceVersion) {
         Log.v(LOG_TAG, "transcribe() called");
 
-        String transcribedText = mPronunciation.transcribe(text, voiceType, voiceVersion);
+        String transcribedText = "";
+        if (voiceType.equals("onnx")) {
+            transcribedText =  mPronunciationVits.transcribe(text, voiceType, voiceVersion);
+        } else {
+            transcribedText = mPronunciation.transcribe(text, voiceType, voiceVersion);
+        }
 
         Log.i(LOG_TAG, text + " => (" + transcribedText + ")");
         return transcribedText;
@@ -61,17 +68,5 @@ public class FrontendManager {
 
     public NormalizationManager getNormalizationManager() {
         return mNormalizationManager;
-    }
-
-    private void initializePronunciation(Context context) {
-        if (mPronunciation == null) {
-            mPronunciation = new Pronunciation(context);
-        }
-    }
-
-    private void initializeNormalizationManager(Context context) {
-        if (mNormalizationManager == null) {
-            mNormalizationManager = new NormalizationManager(context);
-        }
     }
 }

--- a/app/src/main/java/com/grammatek/simaromur/frontend/NormalizationManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/NormalizationManager.java
@@ -59,7 +59,9 @@ public class NormalizationManager {
         List<String> tokenized = mTokenizer.detectSentences(cleaned);
         List<String> normalizedSentences = normalize(tokenized);
         List<String> cleanNormalized = mUnicodeNormalizer.normalizeAlphabet(normalizedSentences);
-
+        for (String sentence : cleanNormalized) {
+            Log.v(LOG_TAG, "normalized sentence: " + sentence);
+        }
         return list2string(cleanNormalized);
     }
 

--- a/app/src/main/java/com/grammatek/simaromur/frontend/NormalizationManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/NormalizationManager.java
@@ -56,8 +56,9 @@ public class NormalizationManager {
     public String process(final String text) {
         Log.v(LOG_TAG, "process() called");
         String cleaned = mUnicodeNormalizer.normalizeEncoding(text);
-        List<String> tokenized = mTokenizer.detectSentences(cleaned);
-        List<String> normalizedSentences = normalize(tokenized);
+
+        List<String> strings = mTokenizer.detectSentences(cleaned);
+        List<String> normalizedSentences = normalize(strings);
         List<String> cleanNormalized = mUnicodeNormalizer.normalizeAlphabet(normalizedSentences);
         for (String sentence : cleanNormalized) {
             Log.v(LOG_TAG, "normalized sentence: " + sentence);
@@ -66,25 +67,16 @@ public class NormalizationManager {
     }
 
     // pre-normalization, tagging and final normalization of the sentences in 'tokenized'
-    private List<String> normalize(final List<String> tokenized) {
+    private List<String> normalize(final List<String> strings) {
         String preNormalized;
         List<String> normalized = new ArrayList<>();
 
-        for (String sentence : tokenized) {
+        for (String sentence : strings) {
             preNormalized = mTTSNormalizer.preNormalize(sentence);
             String[] tags = tagText(preNormalized);
             // preNormalized is tokenized as string, so we know splitting on whitespace will give
             // us the correct tokens according to the tokenizer
             String postNormalized = mTTSNormalizer.postNormalize(preNormalized.split(" "), tags);
-            // Some very basic phrasing for longer sentences
-            // TODO: improve!
-            if (tags.length >= 10) {
-                postNormalized = postNormalized.replace(" og ", " " + SymbolsLvLIs.TagPause + " og ");
-                postNormalized = postNormalized.replace(" en ", " " + SymbolsLvLIs.TagPause + " en ");
-                postNormalized = postNormalized.replace(" þegar ", " " + SymbolsLvLIs.TagPause + " þegar ");
-                postNormalized = postNormalized.replace(" sem ", " " + SymbolsLvLIs.TagPause + " sem ");
-                postNormalized = postNormalized.replace(" ef ", " " + SymbolsLvLIs.TagPause + " ef ");
-            }
             normalized.add(postNormalized);
         }
 
@@ -100,15 +92,31 @@ public class NormalizationManager {
         return sb.toString().trim();
     }
 
+    /**
+     * Tags the text with POS tags. If there are no numbers in the text, we can skip the
+     * pos-tagging and return a list of dummy tags that just contain "§" for each token.
+     *
+     * @param text  the text to be tagged
+     * @return      the tags for each token in the text
+     */
     private String[] tagText(final String text) {
-        String[] tags = new String[0];
+        String[] tags;
         String[] tokens = text.split(" ");
-        tags = mPosTagger.tag(tokens);
 
+        // optimization: if there are no numbers in the text, we can skip the pos-tagging
+        // and return a list of dummy tags that just contain "§" for each token
+        if (! text.matches(".*\\d.*")) {
+            tags = new String[tokens.length];
+            for (int i = 0; i < tokens.length; i++) {
+                tags[i] = "§";
+            }
+
+            return tags;
+        }
+        tags = mPosTagger.tag(tokens);
         if (DEBUG) {
             printProbabilities(tags, mPosTagger, tokens);
         }
-
         return tags;
     }
 

--- a/app/src/main/java/com/grammatek/simaromur/frontend/NumberHelper.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/NumberHelper.java
@@ -102,8 +102,7 @@ public class NumberHelper {
         DIGIT_NUMBERS.put("9", " níu");
         //TODO: not sure about this, without context difficult to say if it should be "sil" or not
         // DIGIT_NUMBERS.put("\\-", " <sil>");
-        // deal with this at a later stage, don't want to delete it too early
-        //DIGIT_NUMBERS.put("\\-", "");
+        //DIGIT_NUMBERS.put("\\-", " #");
         DIGIT_NUMBERS.put("\\+", " plús");
         //TODO: if we have more sentences being normalized, this replaces end-of-sentence dot as well. We don't want that
         // DIGIT_NUMBERS.put("\\.", " punktur");

--- a/app/src/main/java/com/grammatek/simaromur/frontend/NumberHelper.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/NumberHelper.java
@@ -67,8 +67,8 @@ public class NumberHelper {
 
     //1.234 or 1 or 12 or 123
     public static final String CARDINAL_THOUSAND_PTRN = "^([1-9]\\.?\\d{3}|[1-9]\\d{0,2})$";
-    //1.234 or 12.345 or 123.456
-    public static final String CARDINAL_MILLION_PTRN = "^[1-9]\\d{0,2}\\.\\d{3}$";
+    //1.234 or 12.345 or 123.456 or 123468
+    public static final String CARDINAL_MILLION_PTRN = "^[1-9]\\d{0,2}\\.?\\d{3}$";
     public static final String CARDINAL_BIG_PTRN = "^[1-9]\\d{0,2}(\\.\\d{3}){2,3}$";
 
     //1.123,4 or 1232,4 or 123,4 or 12,42345 or 1,489

--- a/app/src/main/java/com/grammatek/simaromur/frontend/Pronunciation.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/Pronunciation.java
@@ -24,6 +24,7 @@ public class Pronunciation {
     private final Context mContext;
     private NativeG2P mG2P;
     private Map<String, PronDictEntry> mPronDict;
+    private Map<String, PronDictEntry> mIpaPronDict;
     private final Map<String, Map<String, Map<String, String>>> mAlphabets;
 
     private final static String FLITE = "flite";
@@ -55,8 +56,9 @@ public class Pronunciation {
     }
 
     public Pronunciation(Context context) {
-        this.mContext = context;
-        initializePronDict();
+        mContext = context;
+        mPronDict = readPronDict();
+        mIpaPronDict = readIpaPronDict();
         mAlphabets = initializeAlphabets();
     }
 
@@ -196,17 +198,12 @@ public class Pronunciation {
         return List.copyOf(mAlphabets.keySet());
     }
 
-    private void initializeG2P() {
+    public void initializeG2P() {
         if (mG2P == null) {
             mG2P = new NativeG2P(this.mContext);
         }
     }
 
-    private void initializePronDict() {
-        if (mPronDict == null) {
-            mPronDict = readPronDict();
-        }
-    }
 
     /**
      * Initialize a symbol dictionary where we can look up mappings between all alphabets in ALPHABETS_FILE.
@@ -258,5 +255,32 @@ public class Pronunciation {
            }
        }
         return pronDict;
+    }
+
+    private Map<String, PronDictEntry> readIpaPronDict() {
+        Map<String, PronDictEntry> pronDict = new HashMap<>();
+        final List<String> fileContent = FileUtils.readLinesFromResourceFile(this.mContext,
+                R.raw.igc_wiki_news_dict_20240107);
+        for (String line : fileContent) {
+            String[] transcr = line.trim().split("\t");
+            if (transcr.length == 2) {
+                pronDict.put(transcr[0], new PronDictEntry(transcr[0], transcr[1]));
+            }
+        }
+        return pronDict;
+    }
+
+    public NativeG2P GetG2p() {
+        return mG2P;
+    }
+
+    public Map<String, PronDictEntry> GetPronDict() {
+        return mPronDict;
+    }
+    public Map<String, PronDictEntry> GetIpaPronDict() {
+        return mIpaPronDict;
+    }
+    public Map<String, Map<String, Map<String, String>>> GetAlphabets() {
+        return mAlphabets;
     }
 }

--- a/app/src/main/java/com/grammatek/simaromur/frontend/Pronunciation.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/Pronunciation.java
@@ -92,6 +92,8 @@ public class Pronunciation {
      *   If a symbol in the input string is not found in the respective from alphabet, the symbol is
      *   kept as is and not converted. A message is logged as a warning if this happens.
      *
+     * @note  The symbols need to be separated by a space !
+     *
      * @param transcribed a transcribed string
      * @param fromAlphabet the alphabet of the transcribed string
      * @param toAlphabet the alphabet to convert the transcribed string into
@@ -111,8 +113,13 @@ public class Pronunciation {
 
         StringBuilder converted = new StringBuilder();
         final Map<String, Map<String, String>> currentDict = mAlphabets.get(fromAlphabet);
+        assert currentDict != null;
         for (String symbol : transcribed.split(" ")) {
-            assert currentDict != null;
+            if (symbol.equals("ˈ") || symbol.equals("ˌ")) {
+                converted.append(symbol);
+                converted.append(" ");
+                continue;
+            }
             if (!currentDict.containsKey(symbol)) {
                 Log.w(LOG_TAG, "Symbol (" + symbol + ") seems not to be a valid symbol in " + fromAlphabet +
                         ". Skipping conversion.");

--- a/app/src/main/java/com/grammatek/simaromur/frontend/PronunciationFP2.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/PronunciationFP2.java
@@ -1,0 +1,262 @@
+package com.grammatek.simaromur.frontend;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.grammatek.simaromur.R;
+import com.grammatek.simaromur.device.NativeG2P;
+import com.grammatek.simaromur.device.SymbolsLvLIs;
+import com.grammatek.simaromur.utils.FileUtils;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class manages the dictionary look-ups and the calls to g2p for unknown words
+ */
+
+public class PronunciationFP2 {
+    private final static String LOG_TAG = "Simaromur_" + PronunciationFP2.class.getSimpleName();
+    private final Context mContext;
+    private NativeG2P mG2P;
+    private Map<String, PronDictEntry> mPronDict;
+    private final Map<String, Map<String, Map<String, String>>> mAlphabets;
+
+    private final static String FLITE = "flite";
+    private final String beginEndPausePattern = "^§sp|§sp$";
+
+    // Letters that need custom transcription when spoken in isolation (like when using the
+    // keyboard). This means partly different transcription of the letter than normal/correct
+    // and partly leaving out pause symbols at beginning and/or end.
+    // TODO: these mappings are valid for Álfur Flite v0.2, needs revision when voice is
+    // updated!
+    private static final Map<String, String> CUSTOM_CHAR_TRANSCRIPTS = new HashMap<>();
+    static {
+        CUSTOM_CHAR_TRANSCRIPTS.put("c", "s j E: ");
+        CUSTOM_CHAR_TRANSCRIPTS.put("e", SymbolsLvLIs.SymbolShortPause + " E: E: " + SymbolsLvLIs.SymbolShortPause);
+        CUSTOM_CHAR_TRANSCRIPTS.put("i", "I: " + SymbolsLvLIs.SymbolShortPause);
+        CUSTOM_CHAR_TRANSCRIPTS.put("j", SymbolsLvLIs.SymbolShortPause + " i: O: T " + SymbolsLvLIs.SymbolShortPause);
+        CUSTOM_CHAR_TRANSCRIPTS.put("o", "O: O ");
+        CUSTOM_CHAR_TRANSCRIPTS.put("ó", "ou: " + SymbolsLvLIs.SymbolShortPause);
+        CUSTOM_CHAR_TRANSCRIPTS.put("s", SymbolsLvLIs.SymbolShortPause + " E s s " + SymbolsLvLIs.SymbolShortPause);
+        CUSTOM_CHAR_TRANSCRIPTS.put("u", "Y: " + SymbolsLvLIs.SymbolShortPause);
+        CUSTOM_CHAR_TRANSCRIPTS.put("z", "s E: a t a " + SymbolsLvLIs.SymbolShortPause);
+    }
+    private static final Map<String, String> CUSTOM_TRANSCRIPTS = new HashMap<>();
+    static {
+        CUSTOM_TRANSCRIPTS.put("merki", "m E r_0 r_0 c I ");
+        CUSTOM_TRANSCRIPTS.put("hægri", "h a ai G r I ");
+        CUSTOM_TRANSCRIPTS.put("hæ", "h aii ai ");
+        CUSTOM_TRANSCRIPTS.put("ég", "i j E: x ");
+    }
+
+    public PronunciationFP2(Context context) {
+        this.mContext = context;
+        initializePronDict();
+        mAlphabets = initializeAlphabets();
+    }
+
+    public String transcribe(String text) {
+        return transcribe(text, "", "");
+    }
+
+    public String transcribe(String text, final String voiceType, final String voiceVersion) {
+        initializeG2P();    // lazy initialize to break dependencies
+        String transcript = "";
+        text = text.trim();
+        Log.v(LOG_TAG, "voice version => " + voiceVersion);
+        // If we run into more special handling with different voice types and versions,
+        // we might want to think of another approach to this.
+        // For FLITE and v02 check if 'text' is contained in the custom_char_transcripts map
+        // and return the respective custom transcript if true.
+        if (voiceType.equals(FLITE) && voiceVersion.equals("0.2") &&
+                CUSTOM_CHAR_TRANSCRIPTS.containsKey(text))
+            return CUSTOM_CHAR_TRANSCRIPTS.get(text);
+        else
+            transcript = transcribeString(text, voiceType.equals(FLITE) &&
+                    voiceVersion.equals("0.2"));
+
+        return processPauses(transcript, voiceType);
+    }
+
+    /**
+     *   Converts a transcription in one alphabet to another alphabet.
+     *   Logs an error if either from or to alphabet is not available for conversion and returns
+     *   the original transcribed string.
+     *   If a symbol in the input string is not found in the respective from alphabet, the symbol is
+     *   kept as is and not converted. A message is logged as a warning if this happens.
+     *
+     * @param transcribed a transcribed string
+     * @param fromAlphabet the alphabet of the transcribed string
+     * @param toAlphabet the alphabet to convert the transcribed string into
+     * @param filterUnknown if true, unknown symbols in toAlphabet are filtered out, otherwise
+     *                      they are kept as is
+     * @return a converted transcription
+     */
+    public String convert(String transcribed, String fromAlphabet, String toAlphabet, boolean filterUnknown) {
+        final List<String> validAlpha = getValidAlphabets();
+        if (!validAlpha.contains(fromAlphabet) || !validAlpha.contains(toAlphabet)) {
+            Log.e(LOG_TAG, fromAlphabet + " and/or " + toAlphabet + " is not a valid" +
+                    " phonetic alphabet. Valid alphabets: " + validAlpha);
+            return transcribed;
+        }
+        if (fromAlphabet.equals(toAlphabet))
+            return transcribed;
+
+        StringBuilder converted = new StringBuilder();
+        final Map<String, Map<String, String>> currentDict = mAlphabets.get(fromAlphabet);
+        for (String symbol : transcribed.split(" ")) {
+            assert currentDict != null;
+            if (!currentDict.containsKey(symbol)) {
+                Log.w(LOG_TAG, "Symbol (" + symbol + ") seems not to be a valid symbol in " + fromAlphabet +
+                        ". Skipping conversion.");
+                if (!filterUnknown) {
+                    converted.append(symbol).append(" ");
+                }
+            }
+            else {
+                String convertedSymbol = currentDict.get(symbol).get(toAlphabet);
+                converted.append(convertedSymbol);
+                converted.append(" ");
+            }
+        }
+        return converted.toString().trim();
+    }
+
+    @NonNull
+    private String transcribeString(String text, boolean isFlitev02) {
+        String[] tokens = text.split(" ");
+        StringBuilder sb = new StringBuilder();
+        for (String tok : tokens) {
+            String transcr = "";
+            if (isFlitev02 && CUSTOM_TRANSCRIPTS.containsKey(tok))
+                transcr = CUSTOM_TRANSCRIPTS.get(tok);
+            else if (mPronDict.containsKey(tok)) {
+                transcr = mPronDict.get(tok).getTranscript().trim();
+            }
+            else if (tok.equals(SymbolsLvLIs.TagPause)){
+                transcr = SymbolsLvLIs.SymbolShortPause;
+            }
+            else {
+                transcr = mG2P.process(tok).trim();
+            }
+            // for tokens like 'myllumerki', 'dollarmerki', 'spurningarmerki', etc.
+            // correct transcription does not sound right
+            if (isFlitev02 && transcr.matches(".*m E r_0 c I"))
+                transcr = transcr.replaceAll("m E r_0 c I", "m E r_0 r_0 c I");
+            // Very strange flaw for words ending with "sins", like "leiksins", "tímaritsins", etc.
+            // a very bright "s I n EE s" instead of "s I n s". Fix that with this hack
+            if (isFlitev02 && transcr.matches(".+s I n s"))
+                transcr = transcr.replaceAll("s I n s", "s I n n s");
+
+            // bug in Thrax grammar, catch the error here: insert space before C if missing
+            // like in 'Vilhjálmsdóttur' -> 'v I lC au l m s t ou h t Y r'
+            // TODO: remove when Thrax grammar is fixed!
+            transcr = transcr.replaceAll("([a-zA-Z])C", "$1 C");
+            sb.append(transcr).append(" ");
+        }
+        return sb.toString().trim();
+    }
+
+    // only Flite voices need pause symbols at the beginning and end of a transcript
+    private String processPauses(String transcript, String voiceType) {
+        if (voiceType.equals(FLITE))
+            transcript = ensurePauses(transcript);
+        else
+            transcript = transcript.replaceAll(beginEndPausePattern, "");
+
+        return finalReplacements(transcript);
+    }
+
+    // ensure that each transcript starts and ends with a pause symbol
+    private String ensurePauses(String transcript) {
+        if (!transcript.startsWith(SymbolsLvLIs.SymbolShortPause))
+            transcript = SymbolsLvLIs.SymbolShortPause + " " + transcript;
+        if (!transcript.endsWith(SymbolsLvLIs.SymbolShortPause))
+            transcript += " " + SymbolsLvLIs.SymbolShortPause;
+        return transcript;
+    }
+
+    private String finalReplacements(String transcript) {
+        final String sp = " " + SymbolsLvLIs.SymbolShortPause + " ";
+        final String multiPausePattern = "(§sp ?){2,}";
+        // replace special characters
+        transcript = transcript.replaceAll("\\.", sp);
+        transcript = transcript.replaceAll(",", sp);
+        transcript = transcript.replaceAll("\\s{2,}", " ");
+        transcript = transcript.replaceAll(multiPausePattern, "§sp ").trim();
+        return transcript;
+    }
+
+    private List<String> getValidAlphabets() {
+        return List.copyOf(mAlphabets.keySet());
+    }
+
+    private void initializeG2P() {
+        if (mG2P == null) {
+            mG2P = new NativeG2P(this.mContext);
+        }
+    }
+
+    private void initializePronDict() {
+        if (mPronDict == null) {
+            mPronDict = readPronDict();
+        }
+    }
+
+    /**
+     * Initialize a symbol dictionary where we can look up mappings between all alphabets in ALPHABETS_FILE.
+     * The result is a dictionary of dictionaries, where the top-level keys are the names of the alphabets
+     * and the sub-dictionaries the mappings from a top-level dictionary to all other dictionaries.
+     *
+     * The headers (first line) of the file represent the names of the alphabets.
+     *
+     * Example:
+     *   {'SAMPA' : {'a' : {'IPA' : 'a', 'SINGLE' : 'a', 'FLITE' : 'a'},
+     *              {'a:' : {'IPA' : 'aː', 'SINGLE' : 'A', 'FLITE' : 'aa'},
+     *              { ... }}
+     *    'IPA'   : { ... },
+     *   }
+     * @return a map with phonetic symbols of different alphabets
+     */
+    private Map<String, Map<String, Map<String, String>>> initializeAlphabets() {
+        Map<String, Map<String, Map<String, String>>> alphabets = new HashMap<>();
+        final List<String> fileContent = FileUtils.readLinesFromResourceFile(this.mContext,
+                R.raw.sampa_ipa_single_flite);
+        final List<String> headers = Arrays.asList(fileContent.get(0).split("\t"));
+        for (String header : headers) {
+            int ind = headers.indexOf(header);
+            alphabets.put(header, new HashMap<>());
+            for (int i = 1; i < fileContent.size(); i++) {
+                List<String> symbols = Arrays.asList(fileContent.get(i).split("\t"));
+                String keySymbol = symbols.get(ind);
+                Map<String, String> symbolDict = new HashMap<>();
+                for (String h : headers) {
+                    if (headers.indexOf(h) == ind)
+                        continue;
+                    else
+                        symbolDict.put(h, symbols.get(headers.indexOf(h)));
+                }
+                alphabets.get(header).put(keySymbol, symbolDict);
+            }
+        }
+        return alphabets;
+    }
+
+    private Map<String, PronDictEntry> readPronDict() {
+        Map<String, PronDictEntry> pronDict = new HashMap<>();
+        final List<String> fileContent = FileUtils.readLinesFromResourceFile(this.mContext,
+                R.raw.ice_pron_dict_standard_clear_2201_extended);
+       for (String line : fileContent) {
+           String[] transcr = line.trim().split("\t");
+           if (transcr.length == 2) {
+               pronDict.put(transcr[0], new PronDictEntry(transcr[0], transcr[1]));
+           }
+       }
+        return pronDict;
+    }
+}

--- a/app/src/main/java/com/grammatek/simaromur/frontend/PronunciationFlite.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/PronunciationFlite.java
@@ -1,0 +1,264 @@
+package com.grammatek.simaromur.frontend;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.grammatek.simaromur.R;
+import com.grammatek.simaromur.device.NativeG2P;
+import com.grammatek.simaromur.device.SymbolsLvLIs;
+import com.grammatek.simaromur.utils.FileUtils;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class manages the dictionary look-ups and the calls to g2p for unknown words
+ */
+
+public class PronunciationFlite {
+    private final static String LOG_TAG = "Simaromur_" + PronunciationFlite.class.getSimpleName();
+    private final Context mContext;
+    private NativeG2P mG2P;
+    private Map<String, PronDictEntry> mPronDict;
+    private final Map<String, Map<String, Map<String, String>>> mAlphabets;
+
+    private final static String TYPE_FLITE = "flite";
+    private final static String TYPE_IPA = "ipa";
+    private final String beginEndPausePattern = "^§sp|§sp$";
+
+    // Letters that need custom transcription when spoken in isolation (like when using the
+    // keyboard). This means partly different transcription of the letter than normal/correct
+    // and partly leaving out pause symbols at beginning and/or end.
+    // TODO: these mappings are valid for Álfur Flite v0.2, needs revision when voice is
+    // updated!
+    private static final Map<String, String> CUSTOM_CHAR_TRANSCRIPTS = new HashMap<>();
+    static {
+        CUSTOM_CHAR_TRANSCRIPTS.put("c", "s j E: ");
+        CUSTOM_CHAR_TRANSCRIPTS.put("e", SymbolsLvLIs.SymbolShortPause + " E: E: " + SymbolsLvLIs.SymbolShortPause);
+        CUSTOM_CHAR_TRANSCRIPTS.put("i", "I: " + SymbolsLvLIs.SymbolShortPause);
+        CUSTOM_CHAR_TRANSCRIPTS.put("j", SymbolsLvLIs.SymbolShortPause + " i: O: T " + SymbolsLvLIs.SymbolShortPause);
+        CUSTOM_CHAR_TRANSCRIPTS.put("o", "O: O ");
+        CUSTOM_CHAR_TRANSCRIPTS.put("ó", "ou: " + SymbolsLvLIs.SymbolShortPause);
+        CUSTOM_CHAR_TRANSCRIPTS.put("s", SymbolsLvLIs.SymbolShortPause + " E s s " + SymbolsLvLIs.SymbolShortPause);
+        CUSTOM_CHAR_TRANSCRIPTS.put("u", "Y: " + SymbolsLvLIs.SymbolShortPause);
+        CUSTOM_CHAR_TRANSCRIPTS.put("z", "s E: a t a " + SymbolsLvLIs.SymbolShortPause);
+    }
+    private static final Map<String, String> CUSTOM_TRANSCRIPTS = new HashMap<>();
+    static {
+        CUSTOM_TRANSCRIPTS.put("merki", "m E r_0 r_0 c I ");
+        CUSTOM_TRANSCRIPTS.put("hægri", "h a ai G r I ");
+        CUSTOM_TRANSCRIPTS.put("hæ", "h aii ai ");
+        CUSTOM_TRANSCRIPTS.put("ég", "i j E: x ");
+    }
+
+    public PronunciationFlite(Context context) {
+        this.mContext = context;
+        initializePronDict();
+        mAlphabets = initializeAlphabets();
+    }
+
+    public String transcribe(String text) {
+        return transcribe(text, "", "");
+    }
+
+    public String transcribe(String text, final String voiceType, final String voiceVersion) {
+        initializeG2P();    // lazy initialize to break dependencies
+        String transcript = "";
+        text = text.trim();
+        Log.v(LOG_TAG, "voice version => " + voiceVersion);
+        // If we run into more special handling with different voice types and versions,
+        // we might want to think of another approach to this.
+        // For FLITE and v02 check if 'text' is contained in the custom_char_transcripts map
+        // and return the respective custom transcript if true.
+        if (voiceType.equals(TYPE_FLITE) && voiceVersion.equals("0.2") &&
+                CUSTOM_CHAR_TRANSCRIPTS.containsKey(text))
+            return CUSTOM_CHAR_TRANSCRIPTS.get(text);
+        else if (voiceType.equals(TYPE_FLITE))
+            transcript = transcribeString(text, voiceType.equals(TYPE_FLITE) &&
+                    voiceVersion.equals("0.2"));
+
+        return processPauses(transcript, voiceType);
+    }
+
+    /**
+     *   Converts a transcription in one alphabet to another alphabet.
+     *   Logs an error if either from or to alphabet is not available for conversion and returns
+     *   the original transcribed string.
+     *   If a symbol in the input string is not found in the respective from alphabet, the symbol is
+     *   kept as is and not converted. A message is logged as a warning if this happens.
+     *
+     * @param transcribed a transcribed string
+     * @param fromAlphabet the alphabet of the transcribed string
+     * @param toAlphabet the alphabet to convert the transcribed string into
+     * @param filterUnknown if true, unknown symbols in toAlphabet are filtered out, otherwise
+     *                      they are kept as is
+     * @return a converted transcription
+     */
+    public String convert(String transcribed, String fromAlphabet, String toAlphabet, boolean filterUnknown) {
+        final List<String> validAlpha = getValidAlphabets();
+        if (!validAlpha.contains(fromAlphabet) || !validAlpha.contains(toAlphabet)) {
+            Log.e(LOG_TAG, fromAlphabet + " and/or " + toAlphabet + " is not a valid" +
+                    " phonetic alphabet. Valid alphabets: " + validAlpha);
+            return transcribed;
+        }
+        if (fromAlphabet.equals(toAlphabet))
+            return transcribed;
+
+        StringBuilder converted = new StringBuilder();
+        final Map<String, Map<String, String>> currentDict = mAlphabets.get(fromAlphabet);
+        for (String symbol : transcribed.split(" ")) {
+            assert currentDict != null;
+            if (!currentDict.containsKey(symbol)) {
+                Log.w(LOG_TAG, "Symbol (" + symbol + ") seems not to be a valid symbol in " + fromAlphabet +
+                        ". Skipping conversion.");
+                if (!filterUnknown) {
+                    converted.append(symbol).append(" ");
+                }
+            }
+            else {
+                String convertedSymbol = currentDict.get(symbol).get(toAlphabet);
+                converted.append(convertedSymbol);
+                converted.append(" ");
+            }
+        }
+        return converted.toString().trim();
+    }
+
+
+    @NonNull
+    private String transcribeString(String text, boolean isFlitev02) {
+        String[] tokens = text.split(" ");
+        StringBuilder sb = new StringBuilder();
+        for (String tok : tokens) {
+            String transcr = "";
+            if (isFlitev02 && CUSTOM_TRANSCRIPTS.containsKey(tok))
+                transcr = CUSTOM_TRANSCRIPTS.get(tok);
+            else if (mPronDict.containsKey(tok)) {
+                transcr = mPronDict.get(tok).getTranscript().trim();
+            }
+            else if (tok.equals(SymbolsLvLIs.TagPause)){
+                transcr = SymbolsLvLIs.SymbolShortPause;
+            }
+            else {
+                transcr = mG2P.process(tok).trim();
+            }
+            // for tokens like 'myllumerki', 'dollarmerki', 'spurningarmerki', etc.
+            // correct transcription does not sound right
+            if (isFlitev02 && transcr.matches(".*m E r_0 c I"))
+                transcr = transcr.replaceAll("m E r_0 c I", "m E r_0 r_0 c I");
+            // Very strange flaw for words ending with "sins", like "leiksins", "tímaritsins", etc.
+            // a very bright "s I n EE s" instead of "s I n s". Fix that with this hack
+            if (isFlitev02 && transcr.matches(".+s I n s"))
+                transcr = transcr.replaceAll("s I n s", "s I n n s");
+
+            // bug in Thrax grammar, catch the error here: insert space before C if missing
+            // like in 'Vilhjálmsdóttur' -> 'v I lC au l m s t ou h t Y r'
+            // TODO: remove when Thrax grammar is fixed!
+            transcr = transcr.replaceAll("([a-zA-Z])C", "$1 C");
+            sb.append(transcr).append(" ");
+        }
+        return sb.toString().trim();
+    }
+
+    // only Flite voices need pause symbols at the beginning and end of a transcript
+    private String processPauses(String transcript, String voiceType) {
+        if (voiceType.equals(TYPE_FLITE))
+            transcript = ensurePauses(transcript);
+        else
+            transcript = transcript.replaceAll(beginEndPausePattern, "");
+
+        return finalReplacements(transcript);
+    }
+
+    // ensure that each transcript starts and ends with a pause symbol
+    private String ensurePauses(String transcript) {
+        if (!transcript.startsWith(SymbolsLvLIs.SymbolShortPause))
+            transcript = SymbolsLvLIs.SymbolShortPause + " " + transcript;
+        if (!transcript.endsWith(SymbolsLvLIs.SymbolShortPause))
+            transcript += " " + SymbolsLvLIs.SymbolShortPause;
+        return transcript;
+    }
+
+    private String finalReplacements(String transcript) {
+        final String sp = " " + SymbolsLvLIs.SymbolShortPause + " ";
+        final String multiPausePattern = "(§sp ?){2,}";
+        // replace special characters
+        transcript = transcript.replaceAll("\\.", sp);
+        transcript = transcript.replaceAll(",", sp);
+        transcript = transcript.replaceAll("\\s{2,}", " ");
+        transcript = transcript.replaceAll(multiPausePattern, "§sp ").trim();
+        return transcript;
+    }
+
+    private List<String> getValidAlphabets() {
+        return List.copyOf(mAlphabets.keySet());
+    }
+
+    private void initializeG2P() {
+        if (mG2P == null) {
+            mG2P = new NativeG2P(this.mContext);
+        }
+    }
+
+    private void initializePronDict() {
+        if (mPronDict == null) {
+            mPronDict = readPronDict();
+        }
+    }
+
+    /**
+     * Initialize a symbol dictionary where we can look up mappings between all alphabets in ALPHABETS_FILE.
+     * The result is a dictionary of dictionaries, where the top-level keys are the names of the alphabets
+     * and the sub-dictionaries the mappings from a top-level dictionary to all other dictionaries.
+     *
+     * The headers (first line) of the file represent the names of the alphabets.
+     *
+     * Example:
+     *   {'SAMPA' : {'a' : {'IPA' : 'a', 'SINGLE' : 'a', 'FLITE' : 'a'},
+     *              {'a:' : {'IPA' : 'aː', 'SINGLE' : 'A', 'FLITE' : 'aa'},
+     *              { ... }}
+     *    'IPA'   : { ... },
+     *   }
+     * @return a map with phonetic symbols of different alphabets
+     */
+    private Map<String, Map<String, Map<String, String>>> initializeAlphabets() {
+        Map<String, Map<String, Map<String, String>>> alphabets = new HashMap<>();
+        final List<String> fileContent = FileUtils.readLinesFromResourceFile(this.mContext,
+                R.raw.sampa_ipa_single_flite);
+        final List<String> headers = Arrays.asList(fileContent.get(0).split("\t"));
+        for (String header : headers) {
+            int ind = headers.indexOf(header);
+            alphabets.put(header, new HashMap<>());
+            for (int i = 1; i < fileContent.size(); i++) {
+                List<String> symbols = Arrays.asList(fileContent.get(i).split("\t"));
+                String keySymbol = symbols.get(ind);
+                Map<String, String> symbolDict = new HashMap<>();
+                for (String h : headers) {
+                    if (headers.indexOf(h) == ind)
+                        continue;
+                    else
+                        symbolDict.put(h, symbols.get(headers.indexOf(h)));
+                }
+                alphabets.get(header).put(keySymbol, symbolDict);
+            }
+        }
+        return alphabets;
+    }
+
+    private Map<String, PronDictEntry> readPronDict() {
+        Map<String, PronDictEntry> pronDict = new HashMap<>();
+        final List<String> fileContent = FileUtils.readLinesFromResourceFile(this.mContext,
+                R.raw.ice_pron_dict_standard_clear_2201_extended);
+       for (String line : fileContent) {
+           String[] transcr = line.trim().split("\t");
+           if (transcr.length == 2) {
+               pronDict.put(transcr[0], new PronDictEntry(transcr[0], transcr[1]));
+           }
+       }
+        return pronDict;
+    }
+}

--- a/app/src/main/java/com/grammatek/simaromur/frontend/PronunciationVits.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/PronunciationVits.java
@@ -12,9 +12,11 @@ import com.grammatek.simaromur.utils.FileUtils;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.LinkedHashMap;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -28,117 +30,42 @@ public class PronunciationVits {
     private static final String BOS_SYMBOL = "^";
     private static final String EOS_SYMBOL = "$";
     private final Pronunciation mPronounciation;
-    private final IPAToSAMPAConverter ipaToEspeakConverter;
     private NativeG2P mG2P;
-    private Map<String, PronDictEntry> mPronDict;
-    private final String beginEndPausePattern = "^§sp|§sp$";
+    private final Map<String, PronDictEntry> mPronDict;
+    private final Set<String> Punctuations = new HashSet<>(Arrays.asList(
+            "_", "-", "!", "'", "(", ")", ",", ".", ":", ";", "?", "<", ">", "[", "]", "\"", "#"));
 
+    // This is the place to add custom transcriptions for words that are not in the
+    // dictionary and are not handled by g2p. This is e.g. if we see that certain words are
+    // not handled correctly by g2p, we can add them here.
     private static final Map<String, String> CUSTOM_TRANSCRIPTS = new HashMap<>();
     static {
     }
 
 
-    public class IPAToSAMPAConverter {
-        private final Map<Pattern, String> replacementRules = new LinkedHashMap<>();
-        IPAToSAMPAConverter() {
-            // Define replacement patterns
-            // IPA to eSpeak replacement patterns
-            //replacementRules.put("a", "a");
-            //replacementRules.put("aiː", "aɪ:");
-            replacementRules.put(Pattern.compile("ai"), "aɪ");
-            //replacementRules.put("auː", "aʊː");
-            replacementRules.put(Pattern.compile("au"), "aʊ");
-
-            //replacementRules.put("aː", "aː");
-            replacementRules.put(Pattern.compile("c(?!ʰ)"), "ɟ");
-            replacementRules.put(Pattern.compile("cʰ"), "c");
-            //replacementRules.put("eiː", "eɪː");
-            replacementRules.put(Pattern.compile("ei"), "eɪ");
-
-            //replacementRules.put("f", "f");
-            //replacementRules.put("h", "h");
-            //replacementRules.put("iː", "iː");
-            //replacementRules.put("i", "i");
-            //replacementRules.put("j", "j");
-            replacementRules.put(Pattern.compile("k(?!ʰ)"), "ɡ");
-            replacementRules.put(Pattern.compile("kʰ"), "k");
-            //replacementRules.put("l", "l");
-            // here we have a strange case: the voice doesn't know the symbol '#', eSpeak
-            // transcribes hallo to hˈadlɔ
-            //replacementRules.put(Pattern.compile("l̥"), "l#");
-            replacementRules.put(Pattern.compile("l̥"), "dl");
-            //replacementRules.put("m", "m");
-            replacementRules.put(Pattern.compile("m̥"), "m#");
-            //replacementRules.put("n", "n");
-            replacementRules.put(Pattern.compile("n̥"), "n#");
-            //replacementRules.put("ouː", "oʊː");
-            replacementRules.put(Pattern.compile("ou"), "oʊ");
-
-            replacementRules.put(Pattern.compile("p(?!ʰ)"), "b");
-            replacementRules.put(Pattern.compile("pʰ"), "p");
-            //replacementRules.put("r", "r");
-            replacementRules.put(Pattern.compile("r̥"), "rr#");
-            //replacementRules.put("s", "s");
-            replacementRules.put(Pattern.compile("t(?!ʰ)"), "d");
-            replacementRules.put(Pattern.compile("tʰ"), "t");
-            //replacementRules.put("u", "u");
-            //replacementRules.put("uː", "uː");
-            replacementRules.put(Pattern.compile("v"), "ʋ");
-            //replacementRules.put("x", "x");
-            //replacementRules.put(Pattern.compile("ç"), "ç");
-            //replacementRules.put("ð", "ð");
-            //replacementRules.put("ŋ", "ŋ");
-            replacementRules.put(Pattern.compile("ŋ̊"), "ŋ #");
-            //replacementRules.put("œ", "œ");
-            replacementRules.put(Pattern.compile("œy"), "øy");
-            //replacementRules.put(Pattern.compile("œyː"), "øyː");
-            //replacementRules.put(Pattern.compile("œː"), "œː");
-            //replacementRules.put("ɔ", "ɔ");
-            //replacementRules.put("ɔi", "ɔi");
-            //replacementRules.put("ɔː", "ɔː");
-            //replacementRules.put("ɛ", "ɛ");
-            //replacementRules.put("ɛː", "ɛː");
-            //replacementRules.put("ɣ", "ɣ");
-            //replacementRules.put("ɪ", "ɪ");
-            ///replacementRules.put("ɪː", "ɪː");
-            //replacementRules.put("ɲ", "ɲ");
-            //replacementRules.put("ɲ̊", "ɲ̊");
-            replacementRules.put(Pattern.compile("ʏ"), "y");
-            //replacementRules.put("ʏi", "yi");
-            //replacementRules.put("ʏː", "yː");
-            //replacementRules.put(Pattern.compile("θ"), "θ");
-
-            // Handle stresses
-            //replacementRules.put("ˈ", "'");
-            //replacementRules.put("ˌ", ",");
-            // ... other diacritics if necessary ...
-        }
-
-
-        public String convertIPAToESPEAK(String ipaString) {
-            String espeakString = ipaString;
-
-            for (Map.Entry<Pattern, String> entry : replacementRules.entrySet()) {
-                Matcher matcher = entry.getKey().matcher(espeakString);
-                espeakString = matcher.replaceAll(entry.getValue());
-            }
-
-            return espeakString;
-        }
-    }
-
     public PronunciationVits(Pronunciation pronunciation) {
         // here we just save references to the objects, these need to be initialized before
         this.mPronounciation = pronunciation;
         this.mPronDict = pronunciation.GetIpaPronDict();
-        this.ipaToEspeakConverter = new IPAToSAMPAConverter();
     }
 
     public String transcribe(String text) {
         return transcribe(text, "", "");
     }
 
+    /**
+     * Transcribe text to IPA symbols. Punctuation is kept as is, which conforms to the kind of
+     * IPA dialect encoded into the VITS model.
+     *
+     * @param text          The text to be transcribed to IPA phonemes
+     * @param voiceType     The voice type, e.g. "onnx"
+     * @param voiceVersion  The voice version, e.g. "1.0"
+     *
+     * @return  The transcription as IPA phonemes separated by spaces or empty string if no
+     *          relevant phonemes were found.
+     */
     public String transcribe(String text, final String voiceType, final String voiceVersion) {
+        // lazy initialization of g2p
         if (mPronounciation.GetG2p() == null)
             mPronounciation.initializeG2P();
         mG2P = mPronounciation.GetG2p();
@@ -147,26 +74,69 @@ public class PronunciationVits {
         return doTranscribe(text.trim());
     }
 
+    /**
+     * Transcribe text to IPA. Punctuation is kept as is, which conforms to the IPA dialect
+     * encoded into the VITS model.
+     * <p>
+     * First a small post-normalization cleanup is done, then the text is split into tokens.
+     * Each token is then looked up in the dictionary, if not found, g2p is called. The result
+     * is then converted to IPA and returned. All symbols within a token are separated by PAD_SYMBOL.
+     * Each token is separated by a space.
+     *
+     * @param text  The text to be transcribed to IPA phonemes
+     *
+     * @return The transcription as IPA phonemes separated by spaces or empty string if no
+     *        relevant phonemes were found.
+     */
     @NonNull
     private String doTranscribe(String text) {
-        // if there are multiple commas with space in between, replace them with a single comma
-        text = text.replaceAll(",\\s+,", ",");
-        text = text.replaceAll("<sil>", "");
+        Log.d(LOG_TAG, "****** INITIAL ******  (" + text + ")");
+        if (text.isEmpty() || text.equals(".")) {
+            Log.d(LOG_TAG, "No relevant phonemes found.");
+            return "";
+        }
+
+        // Cleanup before phonemization: multiple commas are unified and only one space between
+        // each token is kept. Also a missing dot at the end is added.
+        text = text.replaceAll(",\\s*,", ",");
+        // replace some common <sil> variants
+        text = text.replaceAll("<sil>\\s*,", ",");
+        text = text.replaceAll("<sil>", "#");
+        // replace all spaces in between with a single space
+        text = text.replaceAll("\\s+", " ").trim();
+
+        // remove beginning comma with surrounding spaces (XXX DS: seems to be replaced from
+        // normalizer for beginning double quotes). This causes an unnatural pause/noise in the
+        // output
+        text = text.replaceAll("^\\s*,\\s*", "");
+
+        // replace all "-" with "#", this is equivalent with <sil> in the VITS model
+        text = text.replaceAll("-", "#");
+
+        // Split text into tokens, cleanup, normalization and post-normalization should have
+        // transformed the sentence into a format that is easy to split
         String[] tokens = text.split("\\s+");
         StringBuilder sb = new StringBuilder();
         for (String tok : tokens) {
             String transcr = "";
             String ipaSymbols = "";
             if (CUSTOM_TRANSCRIPTS.containsKey(tok))
-                transcr = CUSTOM_TRANSCRIPTS.get(tok);
+                ipaSymbols = CUSTOM_TRANSCRIPTS.get(tok);
             else if (mPronDict.containsKey(tok)) {
-                transcr = mPronDict.get(tok).getTranscript().trim();
-                ipaSymbols = ipaToEspeakConverter.convertIPAToESPEAK(transcr);
-                Log.i(LOG_TAG, tok + " => " + ipaSymbols);
+                ipaSymbols = mPronDict.get(tok).getTranscript().trim();
+                //Log.d(LOG_TAG, tok + " => " + ipaSymbols);
+            } else if (Punctuations.contains(tok)) {
+                ipaSymbols = tok;
             }
-            else if (tok.equals(SymbolsLvLIs.TagPause)){
+            else if (tok.equals(SymbolsLvLIs.TagPause)) {
                 transcr = SymbolsLvLIs.SymbolShortPause;
-                ipaSymbols = mPronounciation.convert(transcr, "IPA", "ESPEAK", true).trim();
+                ipaSymbols = transcr;
+            }
+            else if (tok.equals(SymbolsLvLIs.PrimaryStress)) {
+                ipaSymbols = SymbolsLvLIs.PrimaryStress;
+            }
+            else if (tok.equals(SymbolsLvLIs.SecondaryStress)) {
+                ipaSymbols = SymbolsLvLIs.SecondaryStress;
             }
             else {
                 transcr = mG2P.process(tok).trim();
@@ -176,20 +146,27 @@ public class PronunciationVits {
                 // TODO: remove when Thrax grammar is fixed!
                 transcr = transcr.replaceAll("([a-zA-Z])C", "$1 C");
                 // transcribe to IPA
-                ipaSymbols = mPronounciation.convert(transcr, "SAMPA", "ESPEAK", true).trim();
-                // remove all eventual spaces in between symbol
-                ipaSymbols = ipaSymbols.replaceAll("\\s+", "");
-                Log.i(LOG_TAG, "****** THRAX ******  " + ipaSymbols);
+                ipaSymbols = mPronounciation.convert(transcr, "SAMPA", "IPA", false).trim();
+                // remove all eventual spaces in between symbol (why ?)
+                //ipaSymbols = ipaSymbols.replaceAll("\\s+", "");
+                Log.d(LOG_TAG, "****** THRAX ******  (" + transcr + ": " + ipaSymbols + ")");
             }
 
-            sb.append(ipaSymbols).append(" ");
-        }
-        String transcript = sb.toString().replaceAll(beginEndPausePattern, "").replaceAll("§sp", ",").trim();
-        // check if last element ends with "." and if not, append it
-        if (!transcript.endsWith("."))
-            transcript += ".";
+            // To distinguish between words and symbols, we add a space after each word, but use
+            // PAD_SYMBOL to separate the symbols within a word
 
-        return transcript;
+            // replace all spaces in between with PAD_SYMBOL
+            ipaSymbols = ipaSymbols.replaceAll("\\s+", PAD_SYMBOL);
+
+            // after each symbol, we add a space, because this is the normal word/symbol boundary,
+            // but not for punctuations like commas, dots, question marks, colons, semicolons, exclamation marks
+            //if (! ipaSymbols.matches(",\\.\\?!:;"))
+                sb.append(ipaSymbols).append(" ");
+        }
+        String rv = sb.toString().trim();
+        Log.d(LOG_TAG, "****** FINAL after g2p ******  (" + rv + ")");
+        //String transcript = sb.toString().replaceAll(beginEndPausePattern, "").replaceAll("§sp", ",").trim();
+        return rv;
     }
 
 }

--- a/app/src/main/java/com/grammatek/simaromur/frontend/PronunciationVits.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/PronunciationVits.java
@@ -1,0 +1,195 @@
+package com.grammatek.simaromur.frontend;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.grammatek.simaromur.R;
+import com.grammatek.simaromur.device.NativeG2P;
+import com.grammatek.simaromur.device.SymbolsLvLIs;
+import com.grammatek.simaromur.utils.FileUtils;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class manages the dictionary look-ups and the calls to g2p for unknown words
+ */
+
+public class PronunciationVits {
+    private final static String LOG_TAG = "Simaromur_" + PronunciationVits.class.getSimpleName();
+    private static final String PAD_SYMBOL = "_";
+    private static final String BOS_SYMBOL = "^";
+    private static final String EOS_SYMBOL = "$";
+    private final Pronunciation mPronounciation;
+    private final IPAToSAMPAConverter ipaToEspeakConverter;
+    private NativeG2P mG2P;
+    private Map<String, PronDictEntry> mPronDict;
+    private final String beginEndPausePattern = "^§sp|§sp$";
+
+    private static final Map<String, String> CUSTOM_TRANSCRIPTS = new HashMap<>();
+    static {
+    }
+
+
+    public class IPAToSAMPAConverter {
+        private final Map<Pattern, String> replacementRules = new LinkedHashMap<>();
+        IPAToSAMPAConverter() {
+            // Define replacement patterns
+            // IPA to eSpeak replacement patterns
+            //replacementRules.put("a", "a");
+            //replacementRules.put("aiː", "aɪ:");
+            replacementRules.put(Pattern.compile("ai"), "aɪ");
+            //replacementRules.put("auː", "aʊː");
+            replacementRules.put(Pattern.compile("au"), "aʊ");
+
+            //replacementRules.put("aː", "aː");
+            replacementRules.put(Pattern.compile("c(?!ʰ)"), "ɟ");
+            replacementRules.put(Pattern.compile("cʰ"), "c");
+            //replacementRules.put("eiː", "eɪː");
+            replacementRules.put(Pattern.compile("ei"), "eɪ");
+
+            //replacementRules.put("f", "f");
+            //replacementRules.put("h", "h");
+            //replacementRules.put("iː", "iː");
+            //replacementRules.put("i", "i");
+            //replacementRules.put("j", "j");
+            replacementRules.put(Pattern.compile("k(?!ʰ)"), "ɡ");
+            replacementRules.put(Pattern.compile("kʰ"), "k");
+            //replacementRules.put("l", "l");
+            // here we have a strange case: the voice doesn't know the symbol '#', eSpeak
+            // transcribes hallo to hˈadlɔ
+            //replacementRules.put(Pattern.compile("l̥"), "l#");
+            replacementRules.put(Pattern.compile("l̥"), "dl");
+            //replacementRules.put("m", "m");
+            replacementRules.put(Pattern.compile("m̥"), "m#");
+            //replacementRules.put("n", "n");
+            replacementRules.put(Pattern.compile("n̥"), "n#");
+            //replacementRules.put("ouː", "oʊː");
+            replacementRules.put(Pattern.compile("ou"), "oʊ");
+
+            replacementRules.put(Pattern.compile("p(?!ʰ)"), "b");
+            replacementRules.put(Pattern.compile("pʰ"), "p");
+            //replacementRules.put("r", "r");
+            replacementRules.put(Pattern.compile("r̥"), "rr#");
+            //replacementRules.put("s", "s");
+            replacementRules.put(Pattern.compile("t(?!ʰ)"), "d");
+            replacementRules.put(Pattern.compile("tʰ"), "t");
+            //replacementRules.put("u", "u");
+            //replacementRules.put("uː", "uː");
+            replacementRules.put(Pattern.compile("v"), "ʋ");
+            //replacementRules.put("x", "x");
+            //replacementRules.put(Pattern.compile("ç"), "ç");
+            //replacementRules.put("ð", "ð");
+            //replacementRules.put("ŋ", "ŋ");
+            replacementRules.put(Pattern.compile("ŋ̊"), "ŋ #");
+            //replacementRules.put("œ", "œ");
+            replacementRules.put(Pattern.compile("œy"), "øy");
+            //replacementRules.put(Pattern.compile("œyː"), "øyː");
+            //replacementRules.put(Pattern.compile("œː"), "œː");
+            //replacementRules.put("ɔ", "ɔ");
+            //replacementRules.put("ɔi", "ɔi");
+            //replacementRules.put("ɔː", "ɔː");
+            //replacementRules.put("ɛ", "ɛ");
+            //replacementRules.put("ɛː", "ɛː");
+            //replacementRules.put("ɣ", "ɣ");
+            //replacementRules.put("ɪ", "ɪ");
+            ///replacementRules.put("ɪː", "ɪː");
+            //replacementRules.put("ɲ", "ɲ");
+            //replacementRules.put("ɲ̊", "ɲ̊");
+            replacementRules.put(Pattern.compile("ʏ"), "y");
+            //replacementRules.put("ʏi", "yi");
+            //replacementRules.put("ʏː", "yː");
+            //replacementRules.put(Pattern.compile("θ"), "θ");
+
+            // Handle stresses
+            //replacementRules.put("ˈ", "'");
+            //replacementRules.put("ˌ", ",");
+            // ... other diacritics if necessary ...
+        }
+
+
+        public String convertIPAToESPEAK(String ipaString) {
+            String espeakString = ipaString;
+
+            for (Map.Entry<Pattern, String> entry : replacementRules.entrySet()) {
+                Matcher matcher = entry.getKey().matcher(espeakString);
+                espeakString = matcher.replaceAll(entry.getValue());
+            }
+
+            return espeakString;
+        }
+    }
+
+    public PronunciationVits(Pronunciation pronunciation) {
+        // here we just save references to the objects, these need to be initialized before
+        this.mPronounciation = pronunciation;
+        this.mPronDict = pronunciation.GetIpaPronDict();
+        this.ipaToEspeakConverter = new IPAToSAMPAConverter();
+    }
+
+    public String transcribe(String text) {
+        return transcribe(text, "", "");
+    }
+
+    public String transcribe(String text, final String voiceType, final String voiceVersion) {
+        if (mPronounciation.GetG2p() == null)
+            mPronounciation.initializeG2P();
+        mG2P = mPronounciation.GetG2p();
+        assert(mG2P != null);
+
+        return doTranscribe(text.trim());
+    }
+
+    @NonNull
+    private String doTranscribe(String text) {
+        // if there are multiple commas with space in between, replace them with a single comma
+        text = text.replaceAll(",\\s+,", ",");
+        text = text.replaceAll("<sil>", "");
+        String[] tokens = text.split("\\s+");
+        StringBuilder sb = new StringBuilder();
+        for (String tok : tokens) {
+            String transcr = "";
+            String ipaSymbols = "";
+            if (CUSTOM_TRANSCRIPTS.containsKey(tok))
+                transcr = CUSTOM_TRANSCRIPTS.get(tok);
+            else if (mPronDict.containsKey(tok)) {
+                transcr = mPronDict.get(tok).getTranscript().trim();
+                ipaSymbols = ipaToEspeakConverter.convertIPAToESPEAK(transcr);
+                Log.i(LOG_TAG, tok + " => " + ipaSymbols);
+            }
+            else if (tok.equals(SymbolsLvLIs.TagPause)){
+                transcr = SymbolsLvLIs.SymbolShortPause;
+                ipaSymbols = mPronounciation.convert(transcr, "IPA", "ESPEAK", true).trim();
+            }
+            else {
+                transcr = mG2P.process(tok).trim();
+
+                // bug in Thrax grammar, catch the error here: insert space before C if missing
+                // like in 'Vilhjálmsdóttur' -> 'v I lC au l m s t ou h t Y r'
+                // TODO: remove when Thrax grammar is fixed!
+                transcr = transcr.replaceAll("([a-zA-Z])C", "$1 C");
+                // transcribe to IPA
+                ipaSymbols = mPronounciation.convert(transcr, "SAMPA", "ESPEAK", true).trim();
+                // remove all eventual spaces in between symbol
+                ipaSymbols = ipaSymbols.replaceAll("\\s+", "");
+                Log.i(LOG_TAG, "****** THRAX ******  " + ipaSymbols);
+            }
+
+            sb.append(ipaSymbols).append(" ");
+        }
+        String transcript = sb.toString().replaceAll(beginEndPausePattern, "").replaceAll("§sp", ",").trim();
+        // check if last element ends with "." and if not, append it
+        if (!transcript.endsWith("."))
+            transcript += ".";
+
+        return transcript;
+    }
+
+}

--- a/app/src/main/java/com/grammatek/simaromur/frontend/TTSNormalizer.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/TTSNormalizer.java
@@ -33,13 +33,12 @@ public class TTSNormalizer {
                     CardinalThousandTuples.getTuples())
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
-    private final List<CategoryTuple> ThousandsMillionsTupleList = Stream.of(CardinalThousandTuples.getTuples(), CardinalMillionTuples.getTuples())
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
-
     private final List<CategoryTuple> OnesThousandsCardinalTupleList = Stream.of(CardinalOnesTuples.getTuples(), CardinalThousandTuples.getTuples())
             .flatMap(Collection::stream)
                     .collect(Collectors.toList());
+    private final List<CategoryTuple> ThousandsMillionsTupleList = Stream.of(OnesThousandsCardinalTupleList, CardinalMillionTuples.getTuples())
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
     private final List<CategoryTuple> DecimalThousandsTupleList = Stream.of(OnesThousandsCardinalTupleList, DecimalThousandTuples.getTuples())
             .flatMap(Collection::stream)
             .collect(Collectors.toList());

--- a/app/src/main/java/com/grammatek/simaromur/frontend/Tokenizer.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/Tokenizer.java
@@ -187,21 +187,28 @@ public class Tokenizer {
         // for all kinds of punctuation we need to insert spaces at the correct positions
         // Patterns
         String processedToken = token;
+        // Matches a dot followed by a double quote
+        // Example: "text."
+        final String swapDotDoubleQuote = "(\\.)\"";
+        // Matches a comma followed by a double quote
+        final String swapCommaDoubleQuote = "(,)\"";
         // Matches all kinds of opening parentheses and some punctuation
         // Example: "text in (parenthesis)" "a,b,c"
-        String insertSpaceAfterAnywhere = "([(\\[{\\-_,\"?!])";
+        final String insertSpaceAfterAnywhere = "([(\\[{\\-_,\"?!])";
         // Matches all kinds of closing parentheses and some punctuation
         // Example: "text in (parenthesis)" "a,b,c"
-        String insertSpaceBeforeAnywhere = "([)\\]}\\-_,\"?!])";
+        final String insertSpaceBeforeAnywhere = "([)\\]}\\-_,\"?!])";
         // Matches a token ending with ':' or '.'. We don't want to interfere with tokens
         // containing these chars within, that is the task of the normalizer, e.g. urls, etc.
-        String insertSpaceBeforeIfEnd = "(.+)([:.])$";
+        final String insertSpaceBeforeIfEnd = "(.+)([:.])$";
 
         // replacements
+        processedToken = processedToken.replaceAll(swapDotDoubleQuote, "\".");
+        processedToken = processedToken.replaceAll(swapCommaDoubleQuote, "\",");
         processedToken = processedToken.replaceAll(insertSpaceAfterAnywhere, "$1 ");
         processedToken = processedToken.replaceAll(insertSpaceBeforeAnywhere, " $1");
         processedToken = processedToken.replaceAll(insertSpaceBeforeIfEnd, "$1" + " " + "$2");
-      
+
         return processedToken.replaceAll("\\s+", " ").trim();
     }
 

--- a/app/src/main/java/com/grammatek/simaromur/network/remoteasset/VoiceRepo.java
+++ b/app/src/main/java/com/grammatek/simaromur/network/remoteasset/VoiceRepo.java
@@ -60,7 +60,7 @@ public class VoiceRepo {
         // your personal access token is required to avoid rate limiting (60 requests per hour)
         final String oAuthToken = App.getAppRepository().getAssetConfigValueFor("github_auth0_token");
         GitHub gh;
-        if (oAuthToken.isEmpty()) {
+        if (oAuthToken == null || oAuthToken.isEmpty()) {
             gh = GitHub.connectAnonymously();
         } else {
             // this sets the rate limit to 5000 requests per hour

--- a/app/src/main/res/raw/sampa_ipa_single_flite.tsv
+++ b/app/src/main/res/raw/sampa_ipa_single_flite.tsv
@@ -1,60 +1,60 @@
-SAMPA	IPA	SINGLE	FLITE
-a	a	a	a
-ai	ai	3	ai
-ai:	aiː	4	aii
-au	au	z	au
-au:	auː	Z	auu
-a:	aː	A	aa
-c	c	c	c
-c_h	cʰ	C	ch
-ei	ei	1	ei
-ei:	eiː	2	eii
-f	f	f	f
-h	h	h	h
-i	i	y	i
-i:	iː	Y	ii
-j	j	j	j
-k	k	k	k
-k_h	kʰ	K	kh
-l	l	l	l
-l_0	l̥	L	lz
-m	m	m	m
-m_0	m̥	M	mz
-n	n	n	n
-n_0	n̥	N	nz
-ou	ou	x	ou
-ou:	ouː	X	ouu
-p	p	p	p
-p_h	pʰ	P	ph
-r	r	r	r
-r_0	r̥	R	rz
-s	s	s	s
-t	t	t	t
-t_h	tʰ	T	th
-u	u	u	u
-u:	uː	U	uu
-v	v	F	v
-x	x	G	x
-C	ç	H	C
-D	ð	D	D
-N	ŋ	b	N
-N_0	ŋ̊	B	Nz
-9	œ	8	oe
-9i	œy	5	oei
-9i:	œyː	6	oeii
-9:	œː	9	oee
-O	ɔ	o	O
-Oi	ɔi	7	Oi
-O:	ɔː	O	OO
-E	ɛ	e	E
-E:	ɛː	E	EE
-G	ɣ	g	G
-I	ɪ	i	I
-I:	ɪː	I	II
-J	ɲ	q	J
-J_0	ɲ̊	Q	Jz
-Y	ʏ	v	Y
-Yi	ʏi	w	Yi
-Y:	ʏː	V	YY
-T	θ	d	T
-§sp	§sp	§sp	pau
+SAMPA	IPA	SINGLE	FLITE	ESPEAK
+a	a	a	a	a
+ai	ai	3	ai	aɪ
+ai:	aiː	4	aii	aɪ:
+au	au	z	au	aʊ
+au:	auː	Z	auu	aʊː
+a:	aː	A	aa	aː
+c	c	c	c	ɟ
+c_h	cʰ	C	ch	c
+ei	ei	1	ei	eɪ
+ei:	eiː	2	eii	eɪː
+f	f	f	f	f
+h	h	h	h	h
+i	i	y	i	i
+i:	iː	Y	ii	iː
+j	j	j	j	j
+k	k	k	k	g
+k_h	kʰ	K	kh	k
+l	l	l	l	l
+l_0	l̥	L	lz	l#
+m	m	m	m	m
+m_0	m̥	M	mz	m#
+n	n	n	n	n
+n_0	n̥	N	nz	n#
+ou	ou	x	ou	oʊ
+ou:	ouː	X	ouu	oʊː
+p	p	p	p	b
+p_h	pʰ	P	ph	p
+r	r	r	r	r
+r_0	r̥	R	rz	rr#
+s	s	s	s	s
+t	t	t	t	d
+t_h	tʰ	T	th	t
+u	u	u	u	u
+u:	uː	U	uu	uː
+v	v	F	v	ʋ
+x	x	G	x	x
+C	ç	H	C	ç
+D	ð	D	D	ð
+N	ŋ	b	N	ŋ
+N_0	ŋ̊	B	Nz	ŋ #
+9	œ	8	oe	œ
+9i	œy	5	oei	øy
+9i:	œyː	6	oeii	øyː
+9:	œː	9	oee	œː
+O	ɔ	o	O	ɔ
+Oi	ɔi	7	Oi	ɔi
+O:	ɔː	O	OO	ɔː
+E	ɛ	e	E	ɛ
+E:	ɛː	E	EE	ɛː
+G	ɣ	g	G	ɣ
+I	ɪ	i	I	ɪ
+I:	ɪː	I	II	ɪː
+J	ɲ	q	J	ɲ
+J_0	ɲ̊	Q	Jz	ɲ̊
+Y	ʏ	v	Y	y
+Yi	ʏi	w	Yi	yi
+Y:	ʏː	V	YY	yː
+T	θ	d	T	θ
+§sp	§sp	§sp	pau	§sp

--- a/app/src/main/res/raw/sampa_ipa_single_flite.tsv
+++ b/app/src/main/res/raw/sampa_ipa_single_flite.tsv
@@ -57,4 +57,6 @@ Y	ʏ	v	Y	y
 Yi	ʏi	w	Yi	yi
 Y:	ʏː	V	YY	yː
 T	θ	d	T	θ
+'	'	'	'	'
+ˌ	ˌ	ˌ	ˌ	ˌ
 §sp	§sp	§sp	pau	§sp

--- a/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
+++ b/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
@@ -77,6 +77,14 @@ public class NormalizationManagerTest {
         Map<String, String> digits = new HashMap<>();
         // POS-tagger tags 'mínúta' as accusative, hence the wrong case for 32.
         // should be 'þrítugasta og önnur' (accusative is 'mínútu')
+        digits.put("7", "sjö .");
+        digits.put("77", "sjötíu og sjö .");
+        digits.put("777", "sjö hundruð sjötíu og sjö .");
+        digits.put("7777", "sjö þúsund sjö hundruð sjötíu og sjö .");
+        digits.put("77777", "sjötíu og sjö þúsund sjö hundruð sjötíu og sjö .");
+        digits.put("119273", "hundrað og nítján þúsund tvö hundruð sjötíu og þrjú .");
+        digits.put("77.777", "sjötíu og sjö þúsund sjö hundruð sjötíu og sjö .");
+        digits.put("119.273", "hundrað og nítján þúsund tvö hundruð sjötíu og þrjú .");
         digits.put("(32. mín)", "<sil> þrítugustu og aðra mínúta <sil> .");
         digits.put("(37. mín)", "<sil> þrítugustu og sjöundu mínúta <sil> .");
         digits.put("(24. mín)", "<sil> tuttugustu og fjórðu mínúta <sil> .");

--- a/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
+++ b/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
@@ -33,7 +33,7 @@ public class NormalizationManagerTest {
         String processed = manager.process(input);
         System.out.println(processed);
 
-        assertEquals(", þrítugustu og aðra mínúta , .",
+        assertEquals("<sil> þrítugustu og aðra mínúta <sil> .",
                 processed);
     }
 
@@ -75,15 +75,21 @@ public class NormalizationManagerTest {
 
     private Map<String, String> getDigits() {
         Map<String, String> digits = new HashMap<>();
+        // POS-tagger tags 'mínúta' as accusative, hence the wrong case for 32.
+        // should be 'þrítugasta og önnur' (accusative is 'mínútu')
+        digits.put("(32. mín)", "<sil> þrítugustu og aðra mínúta <sil> .");
+        digits.put("(37. mín)", "<sil> þrítugustu og sjöundu mínúta <sil> .");
+        digits.put("(24. mín)", "<sil> tuttugustu og fjórðu mínúta <sil> .");
         digits.put("1.800.000", "ein milljón og átta hundruð þúsund .");
         digits.put(" 10.000.000", "tíu milljónir .");
         digits.put("876.000", "átta hundruð sjötíu og sex þúsund .");
         digits.put("2.350.000", "tvær milljónir þrjú hundruð og fimmtíu þúsund .");
-        // POS-tagger tags 'mínúta' as accusative, hence the wrong case for 32.
-        // should be 'þrítugasta og önnur' (accusative is 'mínútu')
-        digits.put("(32. mín)", ", þrítugustu og aðra mínúta , .");
-        digits.put("(37. mín)", ", þrítugustu og sjöundu mínúta , .");
-        digits.put("(24. mín)", ", tuttugustu og fjórðu mínúta , .");
+        digits.put("2.350.123", "tvær milljónir þrjú hundruð og fimmtíu þúsund eitt hundrað tuttugu og þrjú .");
+        digits.put("2.357.895", "tvær milljónir þrjú hundruð fimmtíu og sjö þúsund átta hundruð níutíu og fimm .");
+        // TODO: now the difficult ones
+        digits.put(" 10.000.005", "tíu milljónir og fimm .");
+        digits.put(" 10.000.050", "tíu milljónir og fimmtíu .");
+        digits.put(" 10.007.050", "tíu milljónir sjö þúsund og fimmtíu .");
         return digits;
     }
 
@@ -129,7 +135,7 @@ public class NormalizationManagerTest {
                 "dölunum punktur eldfjallafræði og náttúruvárhópur h í .");
         sent.put("kynnast því á dögunum.INSTAGRAM/@anniethorisdottir", "kynnast því á dögunum " +
                 "punktur instagram hjá anniethorisdottir .");
-        sent.put("Mörk Ómars á EM:", "mörk ómars á em .");
+        sent.put("Mörk Ómars á EM:", "mörk ómars á em :");
         sent.put("til áramóta 2021/2022", "til áramóta tvö þúsund tuttugu og eitt <sil> tvö þúsund tuttugu og tvö .");
         sent.put("© grammatek", "höfundarréttur grammatek .");
         sent.put("+", "plús .");
@@ -145,48 +151,48 @@ public class NormalizationManagerTest {
     private Map<String, String> getTestSentences() {
         Map<String, String> testSentences = new HashMap<>();
         testSentences.put("Í gær greindust 78 með COVID-19",
-                "Í gær greindust sjötíu og átta með covid nítján .".toLowerCase());
+                "Í gær greindust sjötíu og átta með covid - nítján .".toLowerCase());
         testSentences.put("Í gær greindust 78 með Covid-19",
-                "Í gær greindust sjötíu og átta með Covid nítján .".toLowerCase());
+                "Í gær greindust sjötíu og átta með Covid - nítján .".toLowerCase());
         testSentences.put("Í gær greindust 78 með covid-19",
-                "Í gær greindust sjötíu og átta með covid nítján .".toLowerCase());
+                "Í gær greindust sjötíu og átta með covid - nítján .".toLowerCase());
         testSentences.put("Í gær greindust 78 með CREW-19",
-                "Í gær greindust sjötíu og átta með crew nítján .".toLowerCase());
+                "Í gær greindust sjötíu og átta með crew - nítján .".toLowerCase());
         testSentences.put("Í gær greindust 78 með ABCD-19",
-                "Í gær greindust sjötíu og átta með a b c d nítján .".toLowerCase());
+                "Í gær greindust sjötíu og átta með a b c d - nítján .".toLowerCase());
         testSentences.put("þetta stóð í 4. gr. laga.",  "þetta stóð í fjórðu grein laga .".toLowerCase());
         testSentences.put("Að jafnaði koma daglega um 48 rútur í Bláa Lónið .",
-                "Að jafnaði koma daglega um fjörutíu <sil> og átta rútur í Bláa Lónið .".toLowerCase());
+                "Að jafnaði koma daglega um fjörutíu og átta rútur í Bláa Lónið .".toLowerCase());
         // should be sport domain, for now we can only set domain=sport manually (where the hyphen
         // is replaced with a space instead of "til")
         testSentences.put("Áfram hélt fjörið í síðari hálfleik og þegar 3. leikhluti var tæplega hálfnaður var staðan 64-52 .",
-                "Áfram hélt fjörið í síðari hálfleik <sil> og <sil> þegar þriðji leikhluti var tæplega hálfnaður var staðan sextíu <sil> og fjögur til fimmtíu <sil> og tvö .".toLowerCase());
+                "Áfram hélt fjörið í síðari hálfleik og þegar þriðji leikhluti var tæplega hálfnaður var staðan sextíu og fjögur til fimmtíu og tvö .".toLowerCase());
         testSentences.put("Viðeignin fer fram í sal FS og hefst klukkan 20 .",
-                "Viðeignin fer fram í sal f s <sil> og hefst klukkan tuttugu .".toLowerCase()); // spelling error!
+                "Viðeignin fer fram í sal f s og hefst klukkan tuttugu .".toLowerCase()); // spelling error!
         testSentences.put("Annars var verði 3500 fyrir tímann !",
-                "Annars var verði þrjú þúsund og fimm hundruð fyrir tímann .".toLowerCase()); // spelling error
+                "Annars var verði þrjú þúsund og fimm hundruð fyrir tímann !".toLowerCase()); // spelling error
         testSentences.put("Af því tilefni verða kynningar um allt land á hinum ýmsu deildum innann SL þriðjudaginn 18. janúar nk. ",
                 "Af því tilefni verða kynningar um allt land á hinum ýmsu deildum innann s l þriðjudaginn átjánda janúar næstkomandi .".toLowerCase());
         testSentences.put("„ Ég kíki daglega á facebook , karfan.is , vf.is , mbl.is , kkí , og utpabroncs.com . “ ",
-                ", Ég kíki daglega á facebook , karfan punktur is , v f punktur is , m b l punktur is , k k í , <sil> og utpabronks punktur com . ,".toLowerCase());
+                "\" Ég kíki daglega á facebook , karfan punktur is , v f punktur is , m b l punktur is , k k í , og utpabronks punktur com . \"".toLowerCase());
         testSentences.put("Arnór Ingvi Traustason 57. mín. Jónas Guðni, sem er 33 ára, hóf fótboltaferil sinn árið 2001.",
-                "Arnór Ingvi Traustason fimmtugasta og sjöunda mínúta . Jónas Guðni , <sil> sem er þrjátíu <sil> og þriggja ára , hóf fótboltaferil sinn árið tvö þúsund <sil> og eitt .".toLowerCase());
+                "Arnór Ingvi Traustason fimmtugasta og sjöunda mínúta . Jónas Guðni , sem er þrjátíu og þriggja ára , hóf fótboltaferil sinn árið tvö þúsund og eitt .".toLowerCase());
         // correct version impossible, since the tagger tags "lóð" and "byggingarreit" as dative, causing "í einni lóð og einum byggingarreit" (regina original does that as well)
         //testSentences.put("Einnig er gert ráð fyrir að sameina lóðir og byggingarreiti við Sjávarbraut 1 - 7 í 1 lóð og 1 byggingarreit.   Miðaverð fyrir fullorðna kr. 5500 ",
         //        "Einnig er gert ráð fyrir að sameina lóðir og byggingarreiti við Sjávarbraut eitt til sjö í eina lóð og einn byggingarreit . Miðaverð fyrir fullorðna krónur fimm þúsund og fimm hundruð .");
         testSentences.put("Einnig er gert ráð fyrir að sameina lóðir og byggingarreiti við Sjávarbraut 1 - 7 í 1 lóð og 1 byggingarreit.   Miðaverð fyrir fullorðna kr. 5500 ",
-                "Einnig er gert ráð fyrir að sameina lóðir <sil> og byggingarreiti við Sjávarbraut eitt til sjö í einni lóð <sil> og einum byggingarreit . Miðaverð fyrir fullorðna krónur fimm þúsund og fimm hundruð .".toLowerCase());
+                "Einnig er gert ráð fyrir að sameina lóðir og byggingarreiti við Sjávarbraut eitt til sjö í einni lóð og einum byggingarreit . Miðaverð fyrir fullorðna krónur fimm þúsund og fimm hundruð .".toLowerCase());
         testSentences.put("Stolt Sea Farm (SSF), fiskeldisarmur norsku skipa- og iðnaðarsamstæðunnar Stolt-Nielsen, jók sölu sína á flatfiski um 53% á öðrum ársfjórðungi 2015.",
-                "Stolt Sea Farm , s s f , , fiskeldisarmur norsku skipa <sil> og iðnaðarsamstæðunnar Stolt Nielsen , jók sölu sína á flatfiski um fimmtíu <sil> og þrjú prósent á öðrum ársfjórðungi tvö þúsund <sil> og fimmtán .".toLowerCase());
+                "Stolt Sea Farm <sil> s s f <sil> , fiskeldisarmur norsku skipa - og iðnaðarsamstæðunnar Stolt - Nielsen , jók sölu sína á flatfiski um fimmtíu og þrjú prósent á öðrum ársfjórðungi tvö þúsund og fimmtán .".toLowerCase());
         testSentences.put("Í janúarbyrjun 1983 var stofnað nýtt hlutafélag, Víkurféttir ehf. sem tók við.",
-                "Í janúarbyrjun nítján hundruð áttatíu <sil> og þrjú var stofnað nýtt hlutafélag , Víkurféttir e h f <sil> sem tók við .".toLowerCase());
+                "Í janúarbyrjun nítján hundruð áttatíu og þrjú var stofnað nýtt hlutafélag , Víkurféttir e h f sem tók við .".toLowerCase());
         testSentences.put("Jarðskjálfti að stærð 3,9 varð fyrir sunnan Kleifarvatn kl. 19:50 í gærkvöldi.",
                 "Jarðskjálfti að stærð þrír komma níu varð fyrir sunnan Kleifarvatn klukkan nítján fimmtíu í gærkvöldi .".toLowerCase());
         // can't interpret "söfnuðu krónum", same error in regina original
         //testSentences.put("Stelpurnar Carmen Diljá Guðbjarnardóttir og Elenora Rós Georgsdóttir söfnuðu 7.046 kr.",
         //        "Stelpurnar Carmen Diljá Guðbjarnardóttir og Elenora Rós Georgsdóttir söfnuðu sjö þúsund fjörutíu og sex krónum .");
         testSentences.put("Stelpurnar Carmen Diljá Guðbjarnardóttir og Elenora Rós Georgsdóttir söfnuðu 7.046 kr.",
-                "Stelpurnar Karmen Diljá Guðbjarnardóttir <sil> og Elenora Rós Georgsdóttir söfnuðu sjö þúsund fjörutíu <sil> og sex krónur .".toLowerCase());
+                "Stelpurnar Karmen Diljá Guðbjarnardóttir og Elenora Rós Georgsdóttir söfnuðu sjö þúsund fjörutíu og sex krónur .".toLowerCase());
         testSentences.put("Hann skoraði 21 stig og tók 12 fráköst.", "Hann skoraði tuttugu og eitt stig og tók tólf fráköst .".toLowerCase());
         testSentences.put("Opna Suðurnesjamótið í pílu fer fram þann 4. desember nk. kl. 13:00 í píluaðstöðu Pílufélags Reykjanesbæjar að Hrannargötu 6. ",
                 "Opna Suðurnesjamótið í pílu fer fram þann fjórða desember næstkomandi klukkan þrettán núll núll ".toLowerCase() +
@@ -195,42 +201,42 @@ public class NormalizationManagerTest {
                 "Karlar eru rétt innan við tvö prósent hjúkrunarfræðinga á Íslandi .".toLowerCase());
         // should be "sjö fimm sjö vélarnar" (same error in original regina)
         testSentences.put("Lendingarnar eru hlutfallslega svo fáar að elstu 757 -vélarnar eru aðeins hálfnaðar hvað líftíma varðar",
-                "Lendingarnar eru hlutfallslega svo fáar að elstu sjö hundruð fimmtíu <sil> og sjö vélarnar eru aðeins hálfnaðar hvað líftíma varðar .".toLowerCase());
+                "Lendingarnar eru hlutfallslega svo fáar að elstu sjö hundruð fimmtíu og sjö - vélarnar eru aðeins hálfnaðar hvað líftíma varðar .".toLowerCase());
         testSentences.put("Á samanlögðu svæði Vesturlands og Vestfjarða voru 4.400 gistinætur sem jafngildir 7,5% fækkun milli ára.",
-                "Á samanlögðu svæði Vesturlands <sil> og Vestfjarða voru fjögur þúsund <sil> og fjögur hundruð gistinætur <sil> sem jafngildir sjö komma fimm prósent fækkun milli ára .".toLowerCase());
+                "Á samanlögðu svæði Vesturlands og Vestfjarða voru fjögur þúsund og fjögur hundruð gistinætur sem jafngildir sjö komma fimm prósent fækkun milli ára .".toLowerCase());
         testSentences.put("Elvar skilaði 22 stigum, þar af 5 af 8 í þriggjastiga.",
-                "Elvar skilaði tuttugu <sil> og tveimur stigum , þar af fimm af átta í þriggjastiga .".toLowerCase());
+                "Elvar skilaði tuttugu og tveimur stigum , þar af fimm af átta í þriggjastiga .".toLowerCase());
         // not possible to get correct looking at next tag, depends on "keyri", direct object in acc
         //testSentences.put("Ég keyri 2000 km á mánuði til og frá vinnu, þetta eru 20 - 25 stundir.",
         //        "Ég keyri tvö þúsund kílómetra á mánuði til og frá vinnu , þetta eru tuttugu til tuttugu og fimm stundir .");
         testSentences.put("Ég keyri 2000 km á mánuði til og frá vinnu, þetta eru 20 - 25 stundir.",
-                "Ég keyri tvö þúsund kílómetrar á mánuði til <sil> og frá vinnu , þetta eru tuttugu til tuttugu <sil> og fimm stundir .".toLowerCase());
+                "Ég keyri tvö þúsund kílómetrar á mánuði til og frá vinnu , þetta eru tuttugu til tuttugu og fimm stundir .".toLowerCase());
         // not possible tu get correct looking at next tag, depends on "Áfangastaðir". Also: should have a dictionary of
         // uppercase token not to separate, like "WOW"
         //testSentences.put("Áfangastaðir WOW air eru nú 31 talsins, 23 innan Evrópu en 8 talsins í Norður Ameríku.",
         //        "Áfangastaðir WOW air eru nú þrjátíu og einn talsins , tuttugu og þrír innan Evrópu en átta talsins í Norður Ameríku .");
         testSentences.put("Áfangastaðir WOW air eru nú 31 talsins, 23 innan Evrópu en 8 talsins í Norður Ameríku.",
-                "Áfangastaðir wow air eru nú þrjátíu <sil> og eins talsins , tuttugu <sil> og þrjú innan Evrópu <sil> en átta talsins í Norður Ameríku .".toLowerCase());
+                "Áfangastaðir wow air eru nú þrjátíu og eins talsins , tuttugu og þrjú innan Evrópu en átta talsins í Norður Ameríku .".toLowerCase());
         testSentences.put("Fyrstu félögin í Danmörku, Noregi og Svíþjóð 1919 og Norræna félagið á Íslandi 29. september árið 1922 .",
-                "Fyrstu félögin í Danmörku , Noregi <sil> og Svíþjóð nítján hundruð <sil> og nítján <sil> og Norræna félagið á Íslandi ".toLowerCase() +
-                        "tuttugasta <sil> og níunda september árið nítján hundruð tuttugu <sil> og tvö .".toLowerCase());
+                "Fyrstu félögin í Danmörku , Noregi og Svíþjóð nítján hundruð og nítján og Norræna félagið á Íslandi ".toLowerCase() +
+                        "tuttugasta og níunda september árið nítján hundruð tuttugu og tvö .".toLowerCase());
         testSentences.put("Vindmyllurnar eru hvor um sig 900 kW og samanlögð raforkuframleiðsla þeirra er áæetluð um 5,4 GWst á ári.",
-                "Vindmyllurnar eru hvor um sig níu hundruð kílóvött <sil> og samanlögð raforkuframleiðsla þeirra er áæetluð um ".toLowerCase() +
+                "Vindmyllurnar eru hvor um sig níu hundruð kílóvött og samanlögð raforkuframleiðsla þeirra er áæetluð um ".toLowerCase() +
                         "fimm komma fjórar Gígavattstundir á ári .".toLowerCase());
         // cannot get "ha" correct (reisa + acc) or "fm" (default: fermetrar, next tag: ')' ) regina does the same
         //testSentences.put("Hollenska fjárfestingafyrirtækið EsBro hyggst reisa 15 ha (150.000 m²) gróðurhús til framleiðslu á tómötum",
         //        "Hollenska fjárfestingafyrirtækið EsBro hyggst reisa fimmtán hektara ( hundrað og fimmtíu þúsund fermetra ) gróðurhús til framleiðslu á tómötum");
         testSentences.put("Hollenska fjárfestingafyrirtækið EsBro hyggst reisa 15 ha (150.000 m²) gróðurhús til framleiðslu á tómötum",
-                "Hollenska fjárfestingafyrirtækið EsBro hyggst reisa fimmtán hektarar , hundrað <sil> og fimmtíu þúsund fermetrar , gróðurhús til framleiðslu á tómötum .".toLowerCase());
+                "Hollenska fjárfestingafyrirtækið EsBro hyggst reisa fimmtán hektarar <sil> hundrað og fimmtíu þúsund fermetrar <sil> gróðurhús til framleiðslu á tómötum .".toLowerCase());
         testSentences.put("Mynd / elg@vf.is", "Mynd skástrik elg hjá v f punktur is .".toLowerCase());
-        testSentences.put("hefur leikið sjö leiki með U-21 árs liðinu.", "hefur leikið sjö leiki með U tuttugu <sil> og eins árs liðinu .".toLowerCase());
-        testSentences.put("er þetta í 23. skiptið sem mótið er haldið .", "er þetta í tuttugasta <sil> og þriðja skiptið <sil> sem mótið er haldið .".toLowerCase());
+        testSentences.put("hefur leikið sjö leiki með U-21 árs liðinu.", "hefur leikið sjö leiki með U - tuttugu og eins árs liðinu .".toLowerCase());
+        testSentences.put("er þetta í 23. skiptið sem mótið er haldið .", "er þetta í tuttugasta og þriðja skiptið sem mótið er haldið .".toLowerCase());
         testSentences.put("Skráning er hafin á http://keflavik.is/fimleikar/ og ef eitthvað er óljóst er hægt að hafa samband í síma 421-6368 eða á fimleikar@keflavik.is",
                 "Skráning er hafin á keflavík punktur is skástrik ".toLowerCase()  +
-                        "fimleikar <sil> og <sil> ef eitthvað er óljóst er hægt að hafa samband í síma fjórir tveir einn sex þrír sex átta eða á fimleikar hjá keflavík punktur is .".toLowerCase());
+                        "fimleikar og ef eitthvað er óljóst er hægt að hafa samband í síma fjórir tveir einn- sex þrír sex átta eða á fimleikar hjá keflavík punktur is .".toLowerCase());
         testSentences.put("Austlæg átt, 5-13 m/s síðdegis.", "Austlæg átt , fimm til þrettán metrar á sekúndu síðdegis .".toLowerCase());
         testSentences.put("hlutfallið á Vestfjörðum þar sem 14,1% íbúa eru innflytjendur",
-                "hlutfallið á Vestfjörðum þar <sil> sem fjórtán komma eitt prósent íbúa eru innflytjendur .".toLowerCase());
+                "hlutfallið á Vestfjörðum þar sem fjórtán komma eitt prósent íbúa eru innflytjendur .".toLowerCase());
         // both we and regina make this error with "mínútu" instead of "mínútur"
         testSentences.put("Hann bætti Íslandsmet sitt í 5.000 m kappakstri um 11 mín.",
                 "Hann bætti Íslandsmet sitt í fimm þúsund metra kappakstri um ellefu mínútu .".toLowerCase());
@@ -241,7 +247,7 @@ public class NormalizationManagerTest {
         //testSentences.put("C4CE6358DF86040CAAEEBC58951B8E133105D3369980D62D109E5B6B75CCE67C_713x0",
         //        "c fjögur c e sex þúsund þrjú hundruð fimmtíu og átta d f átta sex núll fjórir núll c a a e e b c fimm átta níu fimm einn b átta e einn þrír þrír einn núll fimm d þrír þrír sex níu níu átta núll d sextíu og tvö d hundrað og níu e fimm b sex b sjötíu og fimm c c e sextíu og sjö c sjö hundruð og þrettán x núll ."
         //);
-        testSentences.put("Mörk Ómars á EM:", "mörk ómars á em .");
+        testSentences.put("Mörk Ómars á EM:", "mörk ómars á em :");
         testSentences.put("til áramóta 2021/2022", "til áramóta tvö þúsund tuttugu og eitt <sil> tvö þúsund tuttugu og tvö .");
         testSentences.put("© grammatek", "höfundarréttur grammatek .");
         testSentences.put("Álfur P er bestur", "álfur p er bestur .");

--- a/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
+++ b/app/src/test/java/com/grammatek/simaromur/NormalizationManagerTest.java
@@ -86,10 +86,11 @@ public class NormalizationManagerTest {
         digits.put("2.350.000", "tvær milljónir þrjú hundruð og fimmtíu þúsund .");
         digits.put("2.350.123", "tvær milljónir þrjú hundruð og fimmtíu þúsund eitt hundrað tuttugu og þrjú .");
         digits.put("2.357.895", "tvær milljónir þrjú hundruð fimmtíu og sjö þúsund átta hundruð níutíu og fimm .");
-        // TODO: now the difficult ones
         digits.put(" 10.000.005", "tíu milljónir og fimm .");
         digits.put(" 10.000.050", "tíu milljónir og fimmtíu .");
         digits.put(" 10.007.050", "tíu milljónir sjö þúsund og fimmtíu .");
+        digits.put(" 13.080.050", "þrettán milljónir áttatíu þúsund og fimmtíu .");
+        digits.put(" 13.005.025", "þrettán milljónir fimm þúsund tuttugu og fimm .");
         return digits;
     }
 

--- a/app/src/test/java/com/grammatek/simaromur/VoiceRepoTest.java
+++ b/app/src/test/java/com/grammatek/simaromur/VoiceRepoTest.java
@@ -112,9 +112,10 @@ public class VoiceRepoTest {
         final String releaseName = "0.1 test release";
         final ArrayList<String> platforms = new ArrayList<>();
         platforms.add("aarch64");
-        platforms.add("armv7a");
-        platforms.add("x86_64");
-        platforms.add("i686");
+        // it is sufficient to test one platform, since the release info is the same for all platforms
+        // platforms.add("armv7a");
+        // platforms.add("x86_64");
+        // platforms.add("i686");
 
         VoiceRepo voiceRepo = null;
         try {
@@ -138,6 +139,8 @@ public class VoiceRepoTest {
 
     @Test
     public void Test_downloadAllVoicesFromRelease() {
+        // @note this test can only be run with a valid github token, as we will hit the rate limit
+        //       otherwise
         VoiceRepo voiceRepo = null;
         try {
             voiceRepo = new VoiceRepo(mVoiceRepoUrl);

--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,15 @@ allprojects {
         google()
         mavenCentral()
     }
-    tasks.withType(Test) {
-        maxParallelForks = Runtime.runtime.availableProcessors()
+    tasks.withType(Test).tap {
+        configureEach {
+            // maxParallelForks = Runtime.runtime.availableProcessors()
+            maxParallelForks = 2
+            maxHeapSize = "4096m"
+        }
     }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip


### PR DESCRIPTION
_This is a placeholder Pull Request, I will clean this up/amend appropriately, if we have the new voice `is-steinn-xs.onnx` based on our own phonemization._

## Implement a preliminary runtime for VITS voice `is-steinn-medium.onnx`
    
The voice 'is-steinn-medium.onnx' uses phonemization based on the ancient eSpeak IPA dialect and was purely trained on eSpeak phonemizeation.
As we are not using eSpeak inside Símarómur, try a naive approach in emulating the eSpeak IPA dialect and adapt the model inputs with the appropriate phoneme conversions, like padding every symbol with `0`, adding `BOS`, `EOS`, etc.
    
The resulting voice performance is quite acceptable for demo purposes and also shows promising runtime performance.
    
 - add `onnxruntime` for the voice model and add a new `TTSEngineOnnx` class, which does all onnx model loading and inference handling
 - add Pronunciation for VITS via the class `PronunciationVits` and also add appropriate classes for the other used pronunciation formats via classes `PronuncationFP2`, `PronunciationFlite`
- add pronunciation dictionary with `Word -> IPA symbols`. These symbols use a compressed format without any padding or spaces in between. Therefore, we need to retokenize each IPA pronuncation again to split the dictionary entry into single symbols to be able to convert these to the input ids for the VITS model
- Add new pojo class VitsConfig that provides interpretation of the Vits model configuration file to be able to read the `phonetic alphabet -> phoneme id` mapping