### PR TITLE
TTSManager: Fix modality of voice TTS settings dialog

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/TTSManager.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSManager.java
@@ -190,7 +190,7 @@ public class TTSManager extends Activity implements OnItemClickListener, TextToS
     private void openTtsSettings() {
         Intent intent = new Intent();
         intent.setAction("com.android.settings.TTS_SETTINGS");
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
         startActivity(intent);
     }
 


### PR DESCRIPTION
The voice TTS settings activity had a wrong modality option when opened. Change intent flags from `FLAG_ACTIIVITY_NEW_TASK` to `FLAG_ACTIVITY_NO_HISTORY`.

This will change the behaviour like this:

- open activity on top of the TTSManager activity
- close activity when navigating back
- close activity when resuming by navigating back to Símarómur from another app / activity

This fixes / closes #143