### PR TITLE
Use the voice settings for the pitch.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,8 +77,8 @@ android {
         minSdkVersion 26
         compileSdkVersion 34
         targetSdkVersion 34
-        versionCode 35
-        versionName "2.0.3"
+        versionCode 36
+        versionName "2.0.4"
 
         testInstrumentationRunner  "androidx.test.runner.AndroidJUnitRunner"
         // testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/grammatek/simaromur/TTSService.java
+++ b/app/src/main/java/com/grammatek/simaromur/TTSService.java
@@ -145,12 +145,16 @@ public class TTSService extends TextToSpeechService {
             Log.i(LOG_TAG, "onSynthesizeText: speechrate from settings: (" + settingsSpeechRate + ")");
             float clientSpeechRate = speechrate / (settingsSpeechRate / 100.0f);
             speechrate = (int) (adaptedSettingsSpeechRate * clientSpeechRate);
+            // Use the voice settings for the pitch. In contrast to the speech rate, the pitch is
+            // not changeable by e.g. TalkBack, but somehow, we get strange pitch variations via
+            // the request itself and cannot trust it. See also issue #24
+            pitch = Settings.Secure.getInt(getContentResolver(), Settings.Secure.TTS_DEFAULT_PITCH);
         } catch (Exception ex) {
             ex.printStackTrace();
         }
 
         Log.v(LOG_TAG, "onSynthesizeText: (" + language + "/" + country + "/" + variant
-                + "), callerUid: " + callerUid + " effective speed: " + speechrate + " pitch: " + pitch
+                + "), callerUid: " + callerUid + " effective speed: " + speechrate + ", effective pitch: " + pitch
                 + " bundle: " + params);
 
         String loadedVoiceName = mRepository.getLoadedVoiceName();


### PR DESCRIPTION
In contrast to the speech rate, there is no setting in e.g. Talkback to change the pitch on-the-fly.
Somehow and only for some phones, we get nevertheless strange pitch variations per request and unfortunately cannot trust it. Therefore, restore the previous pitch setting behaviour and use the TTS settings menu pitch value of the phone as has been done before for Símarómur versions 2.0.2 and earlier.

See also issue #24