### PR TITLE
Fix the case, where there are no entries inside the normalization dict

### DIFF
--- a/app/src/main/java/com/grammatek/simaromur/frontend/TTSNormalizer.java
+++ b/app/src/main/java/com/grammatek/simaromur/frontend/TTSNormalizer.java
@@ -153,6 +153,9 @@ public class TTSNormalizer {
         // NormDictEntry Db
         String normalized = sentence;
         final HashMap<NormDictEntry, Pattern> entriesMap = App.getAppRepository().getCachedUserDictEntries();
+        if (null == entriesMap)
+            return normalized;
+
         final List<NormDictEntry> entries = new ArrayList<>(entriesMap.keySet());
 
         // sort terms according to their size descendingly to match longer strings first.


### PR DESCRIPTION
Avoid NPE, if there is not yet any user dictionary entry added.